### PR TITLE
Fix user-guide links

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,4 +71,4 @@ Contributions and pull requests are welcome.  See [docs/contributing.md](docs/co
 
 ## The fine print
 
-This product is [licensed](LICENSE.md) under the Apache 2 license.  This is not an officially supported Google project
+This product is [licensed](LICENSE) under the Apache 2 license.  This is not an officially supported Google project


### PR DESCRIPTION
It's user-guide.md rather than the bare user-guide