### PR TITLE
GOBMCN2-131 - DR - role for data guard configuration

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -88,6 +88,8 @@ diskgroup_compatible_rdbms: "{# assign to variable c compatible parameter and se
 run_cluvfy: false
 
 # section for DR
+# db_unique_name for standby is formed as concatenation 
+# of db_name and standby_suffix to provide uniqueness in Data Guard
 standby_suffix: _s
 
 gi_software:

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -88,7 +88,7 @@ diskgroup_compatible_rdbms: "{# assign to variable c compatible parameter and se
 run_cluvfy: false
 
 # section for DR
-standby_suffix: s
+standby_suffix: _s
 
 gi_software:
   - name: 19c_gi

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -87,6 +87,9 @@ diskgroup_compatible_rdbms: "{# assign to variable c compatible parameter and se
 
 run_cluvfy: false
 
+# section for DR
+standby_suffix: s
+
 gi_software:
   - name: 19c_gi
     version: 19.3.0.0.0

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -88,8 +88,12 @@ diskgroup_compatible_rdbms: "{# assign to variable c compatible parameter and se
 run_cluvfy: false
 
 # section for DR
-# db_unique_name for standby is formed as concatenation 
-# of db_name and standby_suffix to provide uniqueness in Data Guard
+
+#db_unique_name identifies uniqueness of a database in Data Guard configuration.
+#By default in the script it set to "_s" so it might be helpful to overwrite the variable
+#and set it to the suffix which identifies location of the standby database
+#(like "_sydney" for example)
+#The same suffix will be "attached" to the db name in DG configuration as well.
 standby_suffix: _s
 
 gi_software:

--- a/roles/dg-config/meta/main.yml
+++ b/roles/dg-config/meta/main.yml
@@ -1,0 +1,17 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+dependencies:
+  - { role: common }

--- a/roles/dg-config/tasks/main.yml
+++ b/roles/dg-config/tasks/main.yml
@@ -16,14 +16,14 @@
 - name: DG | SQL to add standby logs
   set_fact:
     sql_for_dg:  |
-      alter system set dg_broker_start = true;
-      alter system set standby_file_management = auto;
+      alter system set dg_broker_start = true sid='*';
+      alter system set standby_file_management = auto sid='*';
       begin
       for c in (
         select bytes, thr, (max(cnt_log) - nvl(max(cnt_sby), 0)) diff from (
-        select bytes, thread# thr, count(*) cnt_log, null cnt_sby from v\$log where thread# = 1 group by bytes, thread#
+        select bytes, thread# thr, count(*) cnt_log, null cnt_sby from v\$log group by bytes, thread#
         union all
-        select bytes, thread# thr, null cnt_log, count(*) cnt_sby from v\$standby_log where thread# = 1 group by bytes, thread#
+        select bytes, thread# thr, null cnt_log, count(*) cnt_sby from v\$standby_log group by bytes, thread#
         )
         group by bytes, thr
       ) loop
@@ -35,7 +35,7 @@
       /
   tags: dg-create
 
-- name: DG | Change primary database for DG setup
+- name: DG | Enable force logging, set DG parameters and create standby logs on primary
   # start DG broker
   # enable force logging
   # add +1 standby redo groups
@@ -62,7 +62,7 @@
   register: db_change
   tags: dg-create
 
-- name: DG | Changed standby database for DG setup
+- name: DG | Set DG parameters and create standby logs on standby
   shell: |
     set -o pipefail
     {{ oracle_home }}/bin/sqlplus -s / as sysdba << EOF

--- a/roles/dg-config/tasks/main.yml
+++ b/roles/dg-config/tasks/main.yml
@@ -1,0 +1,198 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- name: DG | SQL to add standby logs
+  set_fact:
+    sql_for_dg:  |
+      alter system set dg_broker_start = true;
+      alter system set standby_file_management = auto;
+      begin
+      for c in (
+        select bytes, thr, (max(cnt_log) - nvl(max(cnt_sby), 0)) diff from (
+        select bytes, thread# thr, count(*) cnt_log, null cnt_sby from v\$log where thread# = 1 group by bytes, thread#
+        union all
+        select bytes, thread# thr, null cnt_log, count(*) cnt_sby from v\$standby_log where thread# = 1 group by bytes, thread#
+        )
+        group by bytes, thr
+      ) loop
+        for n in 1..c.diff + 1 loop
+          execute immediate 'alter database add standby logfile thread '||c.thr||' size '||c.bytes;
+        end loop;
+      end loop;
+      end;
+      /
+  tags: dg-create
+
+- name: DG | Change primary database for DG setup
+  # start DG broker
+  # enable force logging
+  # add +1 standby redo groups
+  shell: |
+    set -o pipefail
+    {{ oracle_home }}/bin/sqlplus -s / as sysdba << EOF
+    begin
+    for c in (select force_logging from v\$database) loop
+    if c.force_logging = 'NO' then
+      execute immediate 'alter database force logging';
+    end if;
+    end loop;
+    end;
+    /
+    {{ sql_for_dg }}
+    EOF
+  environment:
+    ORACLE_HOME: "{{ oracle_home }}"
+    ORACLE_SID: "{{ oracle_sid }}"
+    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+  delegate_to: primary1
+  become: yes
+  become_user: "{{ oracle_user }}"
+  register: db_change
+  tags: dg-create
+
+- name: DG | Changed standby database for DG setup
+  shell: |
+    set -o pipefail
+    {{ oracle_home }}/bin/sqlplus -s / as sysdba << EOF
+    {{ sql_for_dg }}
+    EOF
+  environment:
+    ORACLE_HOME: "{{ oracle_home }}"
+    ORACLE_SID: "{{ oracle_sid }}"
+    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+  become: yes
+  become_user: "{{ oracle_user }}"
+  register: db_change
+  tags: dg-create
+
+- name: DG | Script for DG setup
+  template:
+    src: dg-create.j2
+    dest: "{{ oracle_home }}/dbs/create_dg_{{ db_name }}.cmd"
+    owner: "{{ oracle_user }}"
+    group: "{{ oracle_group }}"
+  delegate_to: primary1
+  become: yes
+  become_user: "{{ oracle_user }}"
+  tags: dg-create
+
+- name: DG | Create DG configuration
+  shell: |
+    set -o pipefail
+    {{ oracle_home }}/bin/dgmgrl / << EOF
+    @{{ oracle_home }}/dbs/create_dg_{{ db_name }}.cmd
+    EOF
+  environment:
+    ORACLE_HOME: "{{ oracle_home }}"
+    ORACLE_SID: "{{ oracle_sid }}"
+    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+  delegate_to: primary1
+  become: yes
+  become_user: "{{ oracle_user }}"
+  register: dg_create
+  tags: dg-create
+
+- name: DG | DG creation output
+  debug: var=dg_create.stdout_lines
+  tags: dg-create
+
+- name: DG | Wait for DG to be enabled
+  command: "sleep 60"
+  tags: dg-create
+
+- name: DG | Show DG configuration
+  shell: |
+    set -o pipefail
+    {{ oracle_home }}/bin/dgmgrl / << EOF
+    show configuration verbose
+    EOF
+  environment:
+    ORACLE_HOME: "{{ oracle_home }}"
+    ORACLE_SID: "{{ oracle_sid }}"
+    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+  become: yes
+  become_user: "{{ oracle_user }}"
+  register: dg_create
+  tags: dg-create
+
+- name: DG | DG verbose output
+  debug: var=dg_create.stdout_lines
+  tags: dg-create
+
+- name: DG | Show standby database configuration
+  shell: |
+    set -o pipefail
+    {{ oracle_home }}/bin/dgmgrl / << EOF
+    show database verbose {{ db_name }}{{ standby_suffix }}
+    EOF
+  environment:
+    ORACLE_HOME: "{{ oracle_home }}"
+    ORACLE_SID: "{{ oracle_sid }}"
+    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+  become: yes
+  become_user: "{{ oracle_user }}"
+  register: dg_standby
+  tags: dg-create
+
+- name: DG | Restart standby if required
+  shell: |
+    set -o pipefail
+    {{ oracle_home }}/bin/sqlplus / as sysdba << EOF
+    shutdown immediate
+    startup mount
+    EOF
+  environment:
+    ORACLE_HOME: "{{ oracle_home }}"
+    ORACLE_SID: "{{ oracle_sid }}"
+    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+  when: "'database instance restart required' in dg_standby.stdout"
+  become: yes
+  become_user: "{{ oracle_user }}"
+  tags: dg-create
+
+- name: DG | Enable standby database after restart to clear warnings
+  shell: |
+    set -o pipefail
+    {{ oracle_home }}/bin/dgmgrl / << EOF
+    enable database {{ db_name }}{{ standby_suffix }};
+    show database verbose {{ db_name }}{{ standby_suffix }};
+    EOF
+  environment:
+    ORACLE_HOME: "{{ oracle_home }}"
+    ORACLE_SID: "{{ oracle_sid }}"
+    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+  when: "'database instance restart required' in dg_standby.stdout"
+  become: yes
+  become_user: "{{ oracle_user }}"
+  register: dg_standby
+  tags: dg-create
+
+- name: DG | Add Oracle Restart configuration
+  shell: |
+    set -o pipefail
+    srvctl add db -d {{ db_name }}{{ standby_suffix }} \
+    -oraclehome {{ oracle_home }} {{ "-domain " + db_domain | default(omit) }} \
+    -spfile {{ oracle_home }}/dbs/spfile{{ db_name }}.ora \
+    -pwfile {{ oracle_home }}/dbs/orapw{{ db_name }} \
+    -role PHYSICAL_STANDBY -startoption MOUNT -stopoption IMMEDIATE \
+    -instance {{ oracle_sid }} -dbname {{ db_name }}
+    srvctl start db -d {{ db_name }}{{ standby_suffix }}
+  environment:
+    ORACLE_HOME: "{{ oracle_home }}"
+    ORACLE_SID: "{{ oracle_sid }}"
+    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+  become: yes
+  become_user: "{{ oracle_user }}"
+  tags: dg-create

--- a/roles/dg-config/templates/dg-create.j2
+++ b/roles/dg-config/templates/dg-create.j2
@@ -5,9 +5,6 @@ CONNECT IDENTIFIER IS "//{{ hostvars['primary1'].ansible_ssh_host }}:{{ listener
 ADD DATABASE {{ db_name }}{{ standby_suffix }}
 AS CONNECT IDENTIFIER IS "//{{ ansible_ssh_host }}:{{ listener_port | default(1521, true) }}/{{ db_name }}{{ standby_suffix }}{{ "." + db_domain | default(omit) }}";
 
-SHOW CONFIGURATION VERBOSE;
-
 ENABLE CONFIGURATION;
 
 SHOW CONFIGURATION VERBOSE;
-

--- a/roles/dg-config/templates/dg-create.j2
+++ b/roles/dg-config/templates/dg-create.j2
@@ -1,0 +1,13 @@
+CREATE CONFIGURATION dg_{{ db_name }} AS
+PRIMARY DATABASE IS {{ db_name }}
+CONNECT IDENTIFIER IS "//{{ hostvars['primary1'].ansible_ssh_host }}:{{ listener_port | default(1521, true) }}/{{ db_name }}{{ "." + db_domain | default(omit) }}";
+
+ADD DATABASE {{ db_name }}{{ standby_suffix }}
+AS CONNECT IDENTIFIER IS "//{{ ansible_ssh_host }}:{{ listener_port | default(1521, true) }}/{{ db_name }}{{ standby_suffix }}{{ "." + db_domain | default(omit) }}";
+
+SHOW CONFIGURATION VERBOSE;
+
+ENABLE CONFIGURATION;
+
+SHOW CONFIGURATION VERBOSE;
+


### PR DESCRIPTION
roles/dg-config/meta/main.yml
-- reference to common role

roles/dg-config/tasks/main.yml
-- prepare primary and standby dbs for data guard
-- create data guard configuration
-- enable and verbose data guard configuration

roles/dg-config/templates/dg-create.j2
-- template to create DG config, add database and enable DG

roles/common/defaults/main.yml
-- add standby_suffix for db_unique_name