### PR TITLE
GOBMCN2-131-1 - adjustments to db-copy and dg-config roles

### DIFF
--- a/brute-cleanup.yml
+++ b/brute-cleanup.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ---
-- hosts: all
+- hosts: dbasm
   become: yes
   become_user: root
   pre_tasks:

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -87,6 +87,9 @@ diskgroup_compatible_rdbms: "{# assign to variable c compatible parameter and se
 
 run_cluvfy: false
 
+# ignorance of prerequisites depending on version
+prereq_option: "{% if oracle_ver_base in ('11.2', '12.1') %}-ignorePrereq{% else %}-ignorePrereqFailure{% endif %}"
+
 # section for DR
 
 #db_unique_name identifies uniqueness of a database in Data Guard configuration.
@@ -95,6 +98,12 @@ run_cluvfy: false
 #(like "_sydney" for example)
 #The same suffix will be "attached" to the db name in DG configuration as well.
 standby_suffix: _s
+
+# section size to use during RMAN duplicate
+section_size: 32G
+
+# variable which defines usage of compressed backupsets for duplication
+backupset_compression: true
 
 gi_software:
   - name: 19c_gi

--- a/roles/db-copy/tasks/active-copy.yml
+++ b/roles/db-copy/tasks/active-copy.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 ---
 - name: Active-copy | Check pmon process
-  shell: "set -o pipefail; ps -ef | ( grep pmon || true ) | ( grep -i {{ db_name }} || true ) | ( grep -v grep || true ) | wc -l"
+  shell: "set -o pipefail; ps -ef | ( grep pmon || true ) | ( grep -i {{ oracle_sid }}$ || true ) | ( grep -v grep || true ) | wc -l"
   changed_when: false
   register: pmon_proc
   tags: active-duplicate
@@ -30,13 +30,13 @@
 
 - name: Active-copy | Set random password
   set_fact:
-    sys_pass: "{{ lookup('password', '/dev/null length=16 chars=ascii_letters,digits') }}#_"
+    sys_pass: "{{ lookup('password', '/dev/null length=16 chars=ascii_letters,digits') }}0#_"
   tags: active-duplicate
 
-- name: Active-copy | Set sys password for primary db
+- name: Active-copy | Get primary db password file information
   shell: |
     set -o pipefail
-    {{ oracle_home }}/bin/orapwd file={{ oracle_home }}/dbs/orapw{{ db_name }} force=y password={{ sys_pass }}
+    srvctl config db -d {{ db_name }} | grep "^Password file"
   environment:
     ORACLE_HOME: "{{ oracle_home }}"
     ORACLE_SID: "{{ oracle_sid }}"
@@ -44,6 +44,56 @@
   delegate_to: primary1
   become: yes
   become_user: "{{ oracle_user }}"
+  register: srvctl_output
+  tags: active-duplicate
+
+- name: Active-copy | Password file variable
+  set_fact:
+    password_file: "{{ srvctl_output.stdout|regex_replace('^Password file:')|regex_replace('\\s') }}"
+  tags: active-duplicate
+
+- name: Active-copy | Backup password file from file system
+  copy:
+    src: "{% if password_file|length > 0 %}{{ password_file }}{% else %}{{ oracle_home }}/dbs/orapw{{ db_name }}{% endif %}"
+    dest: "{{ oracle_home }}/dbs/orapw{{ db_name }}.{{ lookup('pipe','date +%Y-%m-%d-%H-%M') }}"
+    owner: "{{ oracle_user }}"
+    group: "{{ oracle_group }}"
+    remote_src: true
+  delegate_to: primary1
+  become: yes
+  become_user: "{{ oracle_user }}"
+  when: password_file is not search('^\\+')
+  tags: active-duplicate
+
+- name: Active-copy | Backup password file from ASM
+  shell: |
+    set -o pipefail
+    asmcmd cp {{ password_file }} {{ grid_home }}/dbs/orapw{{ db_name }}.{{ lookup('pipe','date +%Y-%m-%d-%H-%M') }}
+  environment:
+    ORACLE_HOME: "{{ grid_home }}"
+    ORACLE_SID: "{{ asm_sid }}"
+    PATH: "{{ grid_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+  delegate_to: primary1
+  become: yes
+  become_user: "{{ grid_user }}"
+  when: password_file is search('^\\+')
+  tags: active-duplicate
+
+- name: Active-copy | Set sys password for primary db
+  command:
+    argv:
+      - "{{ oracle_home }}/bin/orapwd"
+      - "file={{ oracle_home }}/dbs/orapw{{ db_name }}"
+      - "force=y"
+      - "password={{ sys_pass }}"
+  environment:
+    ORACLE_HOME: "{{ oracle_home }}"
+    ORACLE_SID: "{{ oracle_sid }}"
+    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+  delegate_to: primary1
+  become: yes
+  become_user: "{{ oracle_user }}"
+  no_log: true
   tags: active-duplicate
 
 - name: Active-copy | Add static listener entry
@@ -75,11 +125,12 @@
   tags: active-duplicate
 
 - name: Active-copy | Create auxiliary init file
-  shell: |
-    set -o pipefail
-    (echo "db_name={{ db_name }}"; echo "db_unique_name={{ db_name }}{{ standby_suffix }}") > {{ oracle_home }}/dbs/init{{ oracle_sid }}.ora
+  template:
+    src: initaux.ora.j2
+    dest: "{{ oracle_home }}/dbs/init{{ oracle_sid }}.ora"
+    owner: "{{ oracle_user }}"
+    group: "{{ oracle_group }}"
   become: yes
-  become_user: "{{ oracle_user }}"
   tags: active-duplicate
 
 - name: Active-copy | Start auxiliary instance
@@ -99,39 +150,65 @@
   tags: active-duplicate
 
 - name: Active-copy | Set sys password for auxiliary instance
-  shell: |
-    set -o pipefail
-    {{ oracle_home }}/bin/orapwd file={{ oracle_home }}/dbs/orapw{{ db_name }} force=y password={{ sys_pass }}
+  command:
+    argv:
+      - "{{ oracle_home }}/bin/orapwd"
+      - "file={{ oracle_home }}/dbs/orapw{{ db_name }}"
+      - "force=y"
+      - "password={{ sys_pass }}"
   environment:
     ORACLE_HOME: "{{ oracle_home }}"
     ORACLE_SID: "{{ oracle_sid }}"
     PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+  become: yes
+  become_user: "{{ oracle_user }}"
+  no_log: true
+  tags: active-duplicate
+
+- name: Active-copy | Get duplicate script
+  template:
+    src: duplicate.cmd.j2
+    dest: "{{ oracle_home }}/dbs/duplicate.cmd"
+    owner: "{{ oracle_user }}"
+    group: "{{ oracle_group }}"
   become: yes
   become_user: "{{ oracle_user }}"
   tags: active-duplicate
 
 - name: Active-copy | Duplicate primary database
-  shell: |
-    set -o pipefail
-    {{ oracle_home }}/bin/rman << EOF
-    connect target "sys/{{ sys_pass }}@//{{ lookup('env', 'PRIMARY_IP_ADDR') }}:{{ listener_port | default(1521, true) }}/{{ db_name }}{{ "." + db_domain | default(omit) }}"
-    connect auxiliary "sys/{{ sys_pass }}@//{{ lookup('env', 'INSTANCE_IP_ADDR') }}:{{ listener_port | default(1521, true) }}/{{ db_name }}{{ standby_suffix }}{{ "." + db_domain | default(omit) }}"
-    duplicate target database for standby from active database
-    password file
-    spfile
-      set "db_unique_name"="{{ db_name }}{{ standby_suffix }}"
-    section size {{ section_size | default('32G', true) }}
-    using compressed backupset;
-    EOF
+  command:
+    argv:
+      - "{{ oracle_home }}/bin/rman"
+      - "target \"sys/{{ sys_pass }}@//{{ lookup('env', 'PRIMARY_IP_ADDR') }}:{{ listener_port | default(1521, true) }}/{{ db_name }}{% if db_domain|default('', true)|length > 0 %}.{{ db_domain }}{% endif %}\""
+      - "auxiliary \"sys/{{ sys_pass }}@//{{ lookup('env', 'INSTANCE_IP_ADDR') }}:{{ listener_port | default(1521, true) }}/{{ db_name }}{{ standby_suffix }}{% if db_domain|default('', true)|length > 0 %}.{{ db_domain }}{% endif %}\""
+      - "cmdfile={{ oracle_home }}/dbs/duplicate.cmd"
+      - "log={{ oracle_home }}/dbs/duplicate.log"
   environment:
     ORACLE_HOME: "{{ oracle_home }}"
     ORACLE_SID: "{{ oracle_sid }}"
     PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
-  register: db_copy
   become: yes
   become_user: "{{ oracle_user }}"
+  no_log: true
   tags: active-duplicate
 
-- name: Active-copy | Duplication results
-  debug: var=db_copy.stdout_lines
+- name: Active-copy | Add Oracle Restart configuration
+  shell: |
+    set -o pipefail
+    {{ oracle_home }}/bin/sqlplus -s / as sysdba << EOF
+    shutdown immediate
+    EOF
+    srvctl add db -d {{ db_name }}{{ standby_suffix }} \
+    -oraclehome {{ oracle_home }} {% if db_domain|default('', true)|length > 0 %}-domain {{ db_domain }}{% endif %} \
+    -spfile {{ oracle_home }}/dbs/spfile{{ db_name }}.ora \
+    -pwfile {{ oracle_home }}/dbs/orapw{{ db_name }} \
+    -role PHYSICAL_STANDBY -startoption MOUNT -stopoption IMMEDIATE \
+    -instance {{ oracle_sid }} -dbname {{ db_name }}
+    srvctl start db -d {{ db_name }}{{ standby_suffix }}
+  environment:
+    ORACLE_HOME: "{{ oracle_home }}"
+    ORACLE_SID: "{{ oracle_sid }}"
+    PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+  become: yes
+  become_user: "{{ oracle_user }}"
   tags: active-duplicate

--- a/roles/db-copy/templates/duplicate.cmd.j2
+++ b/roles/db-copy/templates/duplicate.cmd.j2
@@ -1,0 +1,5 @@
+duplicate target database for standby from active database
+spfile
+  set "db_unique_name"="{{ db_name }}{{ standby_suffix }}"
+section size {{ section_size | default('32G', true) }}
+{% if oracle_ver_base != '11.2' %}using {% if backupset_compression | default(false) | bool %}compressed{% endif %} backupset{% endif %};

--- a/roles/db-copy/templates/initaux.ora.j2
+++ b/roles/db-copy/templates/initaux.ora.j2
@@ -1,0 +1,2 @@
+db_name={{ db_name }}
+db_unique_name={{ db_name }}{{ standby_suffix }}

--- a/roles/dg-config/tasks/main.yml
+++ b/roles/dg-config/tasks/main.yml
@@ -188,11 +188,14 @@
     -pwfile {{ oracle_home }}/dbs/orapw{{ db_name }} \
     -role PHYSICAL_STANDBY -startoption MOUNT -stopoption IMMEDIATE \
     -instance {{ oracle_sid }} -dbname {{ db_name }}
-    srvctl start db -d {{ db_name }}{{ standby_suffix }}
   environment:
     ORACLE_HOME: "{{ oracle_home }}"
     ORACLE_SID: "{{ oracle_sid }}"
     PATH: "{{ oracle_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
   become: yes
   become_user: "{{ oracle_user }}"
+  register: db_config
+  failed_when:
+    - "(db_config.rc not in [2]) or ('already exists' not in db_config.stdout)"
+    - db_config.rc not in [0]
   tags: dg-create

--- a/roles/dg-config/templates/dg-create.j2
+++ b/roles/dg-config/templates/dg-create.j2
@@ -1,9 +1,9 @@
 CREATE CONFIGURATION dg_{{ db_name }} AS
 PRIMARY DATABASE IS {{ db_name }}
-CONNECT IDENTIFIER IS "//{{ hostvars['primary1'].ansible_ssh_host }}:{{ listener_port | default(1521, true) }}/{{ db_name }}{{ "." + db_domain | default(omit) }}";
+CONNECT IDENTIFIER IS "//{{ hostvars['primary1'].ansible_ssh_host }}:{{ listener_port | default(1521, true) }}/{{ db_name }}{% if db_domain|default('', true)|length > 0 %}.{{ db_domain }}{% endif %}";
 
 ADD DATABASE {{ db_name }}{{ standby_suffix }}
-AS CONNECT IDENTIFIER IS "//{{ ansible_ssh_host }}:{{ listener_port | default(1521, true) }}/{{ db_name }}{{ standby_suffix }}{{ "." + db_domain | default(omit) }}";
+AS CONNECT IDENTIFIER IS "//{{ ansible_ssh_host }}:{{ listener_port | default(1521, true) }}/{{ db_name }}{{ standby_suffix }}{% if db_domain|default('', true)|length > 0 %}.{{ db_domain }}{% endif %}";
 
 ENABLE CONFIGURATION;
 


### PR DESCRIPTION
GOBMCN2-131-1 - adjustments to db-copy and dg-config roles

brute-cleanup.yml
-- replace hosts all with dbasm to avoid primary group cleanup

roles/db-copy/tasks/active-copy.yml
-- increase complexity of password with digit
-- change conditions for db_domain addition
-- add oracle restart configuration for create standby
-- backup password file of primary
-- change to use command module to avoid showing passwords through ps
-- usage of template for auxiliary init file
-- usage of template for duplication script
-- change to restart standby using srvctl

roles/dg-config/tasks/main.yml
-- add oracle restart configuration if it does not exist

roles/dg-config/templates/dg-create.j2
-- change conditions for db_domain addition

roles/common/defaults/main.yml
-- add variable to define section size
-- add variable to define compression for backupsets

roles/db-copy/templates/duplicate.cmd.j2
-- template for active duplication

roles/db-copy/templates/initaux.ora.j2
-- template for auxiliary init file