### PR TITLE
GOBMCN2-145 - to use prereq_option variable for installer

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -128,8 +128,6 @@ create_db: true
 create_listener: true
 install_gi: true
 install_rdbms: true
-prereq_option: "-ignorePrereq"
-
 
 ## End of non-modifiable variables section
 

--- a/roles/gi-setup/tasks/gi-install.yml
+++ b/roles/gi-setup/tasks/gi-install.yml
@@ -16,7 +16,7 @@
 - name: gi-install | Set facts
   set_fact:
     install_unzip_path: "{{ grid_home }}"
-    installer_command: "{{ grid_home }}/gridSetup.sh"
+    installer_command: "{{ grid_home }}/gridSetup.sh {{ prereq_option }}"
     cluvfy_command: "{{ grid_home }}/runcluvfy.sh stage -pre hacfg -verbose"
   tags: gi-setup
 
@@ -24,11 +24,6 @@
   set_fact:
     install_unzip_path: "{{ swlib_unzip_path }}"
     installer_command: "{{ swlib_unzip_path }}/grid/runInstaller {{ prereq_option }} -waitforcompletion"
-  when: oracle_ver in ['11.2.0.4.0','12.1.0.2.0']
-  tags: gi-setup
-
-- name: gi-install | 11.2 and 12.1 specific cluvfg adjustments
-  set_fact:
     cluvfy_command: "{{ swlib_unzip_path }}/grid/runcluvfy.sh stage -pre hacfg -verbose"
   when: oracle_ver in ['11.2.0.4.0','12.1.0.2.0']
   tags: gi-setup
@@ -170,7 +165,7 @@
 
 - name: gi-install | Set installer command
   set_fact:
-    installer_command: "{{ grid_home }}/gridSetup.sh -silent -responseFile {{ swlib_unzip_path }}/grid_install.rsp {{ rel_patch|default('') }} {{ mgmt_option|default('') }} -ignorePrereqFailure"
+    installer_command: "{{ installer_command }} -silent -responseFile {{ swlib_unzip_path }}/grid_install.rsp {{ rel_patch|default('') }} {{ mgmt_option|default('') }}"
   tags: gi-setup
 
 - name: gi-install | Update GI OPatch

--- a/roles/rac-db-setup/tasks/rac-db-install.yml
+++ b/roles/rac-db-setup/tasks/rac-db-install.yml
@@ -153,7 +153,7 @@
 
 - name: rac-db-install | Set installer command
   set_fact:
-    installer_command: "{{ runinstaller_loc }}/runInstaller -silent -waitforcompletion -responseFile {{ install_unzip_path }}/db_install.rsp {{ rel_patch | default('') }} {% if oneoff_patch_dirs|length > 0 %}-applyOneOffs {{ oneoff_patch_dirs }}{% endif %} -ignorePrereqFailure"
+    installer_command: "{{ runinstaller_loc }}/runInstaller -silent -waitforcompletion -responseFile {{ install_unzip_path }}/db_install.rsp {{ rel_patch | default('') }} {% if oneoff_patch_dirs|length > 0 %}-applyOneOffs {{ oneoff_patch_dirs }}{% endif %} {{ prereq_option }}"
   tags: rac-db,rac-db-install
 
 - name: rac-db-install | Information

--- a/roles/rac-gi-setup/tasks/rac-gi-install.yml
+++ b/roles/rac-gi-setup/tasks/rac-gi-install.yml
@@ -190,7 +190,7 @@
 
 - name: rac-gi-install | Set installer command
   set_fact:
-    installer_command: "{{ grid_home }}/gridSetup.sh -silent -responseFile {{ install_unzip_path }}/gridsetup.rsp {{ has_patch|default('') }} {{ rel_patch|default('') }} {{ mgmt_option|default('') }} -ignorePrereqFailure"
+    installer_command: "{{ grid_home }}/gridSetup.sh -silent -responseFile {{ install_unzip_path }}/gridsetup.rsp {{ has_patch|default('') }} {{ rel_patch|default('') }} {{ mgmt_option|default('') }} {{ prereq_option }}"
   tags: rac-gi,rac-gi-install
 
 - name: rac-gi-install | Information

--- a/roles/rdbms-setup/tasks/rdbms-install.yml
+++ b/roles/rdbms-setup/tasks/rdbms-install.yml
@@ -126,7 +126,7 @@
 
 - name: rdbms-install | Set installer command
   set_fact:
-    installer_command: "{{ runinstaller_loc }}/runInstaller -silent -waitforcompletion -responseFile {{ swlib_unzip_path }}/db_install.rsp {{ rel_patch | default('') }} {% if oneoff_patch_dirs|length > 0 %}-applyOneOffs {{ oneoff_patch_dirs }}{% endif %} -ignorePrereqFailure"
+    installer_command: "{{ runinstaller_loc }}/runInstaller -silent -waitforcompletion -responseFile {{ swlib_unzip_path }}/db_install.rsp {{ rel_patch | default('') }} {% if oneoff_patch_dirs|length > 0 %}-applyOneOffs {{ oneoff_patch_dirs }}{% endif %} {{ prereq_option }}"
   tags: rdbms-setup
 
 - name: rdbms-install | Information


### PR DESCRIPTION
To use prereq_option variable instead of static option for flexibility of installation

group_vars/all.yml
-- remove prereq_option variable since it is used in common variables
-- variable was added to common/defaults/main.yml as part of change GOBMCN2-131-1

roles/gi-setup/tasks/gi-install.yml
-- replace ignorePrereqFailure with variable for flexibility

roles/rac-db-setup/tasks/rac-db-install.yml
-- replace ignorePrereqFailure with variable for flexibility

roles/rac-gi-setup/tasks/rac-gi-install.yml
-- replace ignorePrereqFailure with variable for flexibility

roles/rdbms-setup/tasks/rdbms-install.yml
-- replace ignorePrereqFailure with variable for flexibility