### PR TITLE
Add command-line argument for swap disk

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1079,6 +1079,17 @@ NTP_PREF
 Optional: set only if you need to manually define an NTP server, instead of
 relying on the OS defaults.</td>
 </tr>
+<tr>
+<td>Swap device</td>
+<td><p><pre>
+SWAP_BLK_DEVICE
+--swap-blk-device
+</pre></p></td>
+<td>user defined - no default</td>
+<td>Swap device to optionally create.<br>
+<br>
+Optional: set if you would like a swap partition and swap file created.</td>
+</tr>
 </tbody>
 </table>
 

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -50,7 +50,7 @@ asm_disks: "{{ asm_disk_input | default(asm_disks_default,true) }}"
 #If your RAM size is less than or equal to 2 GB, your swap size should be 1.5 times of the RAM. For example, if your RAM size is 2 GB, you should create swap space of 3GB
 #If your RAM size is between 2 GB and 16 GB, your swap size should be the same size of the RAM. For example, if your RAM size is 4 GB, you should create swap space of 4GB
 #If your RAM size is more than 16 GB, your swap size should be 16 GB. For example, if your RAM size is 32 GB, it is enough if you create a swap space of 16GB
-swap_blk_device: /dev/sdg
+swap_blk_device: "{{ lookup('env','SWAP_BLK_DEVICE')|lower|default('',true) }}"
 
 # ntp preferred server
 ntp_preferred: "{{ lookup('env','NTP_PREF')|lower|default('',true) }}"

--- a/install-oracle.sh
+++ b/install-oracle.sh
@@ -223,6 +223,9 @@ INSTANCE_SSH_EXTRA_ARGS_PARAM="^/.+$"
 NTP_PREF="${NTP_PREF}"
 NTP_PREF_PARAM=".*"
 
+SWAP_BLK_DEVICE="${SWAP_BLK_DEVICE}"
+SWAP_BLK_DEVICE_PARAM=".*"
+
 COMPATIBLE_RDBMS="${COMPATIBLE_RDBMS:-0}"
 COMPATIBLE_RDBMS_PARAM="^[0-9][0-9]\.[0-9].*"
 
@@ -443,6 +446,10 @@ while true; do
     ;;
   --ntp-pref)
     NTP_PREF="$2"
+    shift;
+    ;;
+  --swap-blk-device)
+    SWAP_BLK_DEVICE="$2"
     shift;
     ;;
   --check-instance)
@@ -678,6 +685,10 @@ shopt -s nocasematch
 }
 [[ ! "$NTP_PREF" =~ $NTP_PREF_PARAM ]] && {
     echo "Incorrect parameter provided for ntp-pref: $NTP_PREF"
+    exit 1
+}
+[[ ! "$SWAP_BLK_DEVICE" =~ $SWAP_BLK_DEVICE_PARAM ]] && {
+    echo "Incorrect parameter provided for swap-blk-device: $SWAP_BLK_DEVICE"
     exit 1
 }
 [[ ! "$COMPATIBLE_RDBMS" =~ $COMPATIBLE_RDBMS_PARAM ]] && {

--- a/roles/base-provision/tasks/main.yml
+++ b/roles/base-provision/tasks/main.yml
@@ -129,11 +129,8 @@
     state: present
   tags: etchosts
 
-- name: prep host | create swap on GCE
+- name: prep host | create swap
   include_tasks: swap.yml
   when:
-    - ansible_system_vendor == "Google"
-    - ansible_virtualization_type == "kvm"
-    - ansible_virtualization_role == "guest"
     - swap_blk_device is defined
     - swap_blk_device|length > 0

--- a/roles/base-provision/tasks/swap.yml
+++ b/roles/base-provision/tasks/swap.yml
@@ -16,6 +16,7 @@
 - name: swap | Create swap partition
   parted:
     device: "{{ swap_blk_device }}"
+    flags: [ swap ]
     number: 1
     state: present
   register: swapfile_register_create


### PR DESCRIPTION
The Oracle installer requires swap to exist, so it can be convenient to
create swap as part of installation.  Formerly this was done only on GCE
VMs, and had a hard-coded default of /dev/sdg.  Here instead, we remove
the default (which may not match the install location), and permit swap
creation on any platform.  This parameter is optional, and, if not
specified, swap will not be created at all.