### PR TITLE
Avoid cleaning up non-partitioned devices

### DIFF
--- a/roles/brute-ora-cleanup/tasks/main.yml
+++ b/roles/brute-ora-cleanup/tasks/main.yml
@@ -198,6 +198,7 @@
   command: "blockdev --rereadpt {{ item.blk_device }}"
   with_items:
     - "{{ oracle_user_data_mounts }}"
+  when: "'mapper' not in item.blk_device"
   ignore_errors: true
 
 - name: Delete partition all ASM disks
@@ -208,6 +209,7 @@
   with_subelements:
     - "{{ asm_disks }}"
     - disks
+  when: "'mapper' not in item.blk_device"
   ignore_errors: true
   tags: asm-disks
 


### PR DESCRIPTION
On installation, we do not create partition tables on devices containing the word "mapper" (as they are presumed to be managed separately through the device mapper).  We should avoid attempting to remove them on cleanup, to avoid a spurious (though ignored) error message.