### PR TITLE
Prefer multipath devices in ASMlib scan order

### DIFF
--- a/roles/ora-host/tasks/main.yml
+++ b/roles/ora-host/tasks/main.yml
@@ -331,7 +331,7 @@
   become: yes
   become_user: root
   shell: |
-    /usr/sbin/oracleasm configure -e -u {{ grid_user }} -g {{ grid_group }} -b -s y -o "multipath sd"
+    /usr/sbin/oracleasm configure -e -u {{ grid_user }} -g {{ grid_group }} -b -s y -o "dm multipath"
     /usr/sbin/oracleasm init
     /usr/sbin/oracleasm status
     /usr/sbin/oracleasm scandisks

--- a/roles/ora-host/tasks/main.yml
+++ b/roles/ora-host/tasks/main.yml
@@ -331,7 +331,7 @@
   become: yes
   become_user: root
   shell: |
-    /usr/sbin/oracleasm configure -e -u {{ grid_user }} -g {{ grid_group }} -b -s y
+    /usr/sbin/oracleasm configure -e -u {{ grid_user }} -g {{ grid_group }} -b -s y -o "multipath sd"
     /usr/sbin/oracleasm init
     /usr/sbin/oracleasm status
     /usr/sbin/oracleasm scandisks


### PR DESCRIPTION
The classic ASMlib configuration mistake is to map to underlying SD devices rather than multipaths, and then crash out when a path fails over.  Quoting https://www.oracle.com/linux/technologies/multipath-disks.html:

"Multipath Disks First

The system administrator configures ASMLib to scan the multipath disks first. In the ASMLib configuration file she edits the ORACLEASM_SCANORDER variable to look like so:

ORACLEASM_SCANORDER="multipath sd"

During a scan, ASMLib first tries all disks that start with "multipath". The multipath device /dev/multipatha certainly matches. It is scanned first. Next, ASMLib tries all disks that start with "sd". This is all the SCSI disks. The local disk /dev/sda will be scanned, but it is not an ASM disk. The single path disks /dev/sdb and /dev/sdc are also scanned. They are ASM disks, but ASMLib will see that it already has a path to that disk. It will ignore them. Finally, ASMLib will scan any other disks that did not match either prefix."