### PR TITLE
Added -g to ntpd to allow clock set regardless of time difference

### DIFF
--- a/roles/base-provision/defaults/main.yml
+++ b/roles/base-provision/defaults/main.yml
@@ -29,3 +29,4 @@ packages:
 
 swap_blk_device: ""
 ntp_preferred: ""
+ntp_options: "-g"

--- a/roles/base-provision/tasks/main.yml
+++ b/roles/base-provision/tasks/main.yml
@@ -49,11 +49,11 @@
     lock_timeout: 180
   tags: os_packages
 
-- name: Ensure "-g" is present in /etc/sysconfig/ntpd
+- name: Update OPTIONS in /etc/sysconfig/ntpd
   lineinfile:
     dest: /etc/sysconfig/ntpd
     regexp: '^OPTIONS='
-    line: 'OPTIONS="-g"'
+    line: 'OPTIONS="{{ ntp_options }}"'
   notify: restart ntpd
 
 - name: Add ntp preferred server

--- a/roles/base-provision/tasks/main.yml
+++ b/roles/base-provision/tasks/main.yml
@@ -49,12 +49,12 @@
     lock_timeout: 180
   tags: os_packages
 
-- name: Make sure ntp is running
-  service:
-    name: ntpd
-    state: started
-    enabled: yes
-  tags: ntp
+- name: Ensure "-g" is present in /etc/sysconfig/ntpd
+  lineinfile:
+    dest: /etc/sysconfig/ntpd
+    regexp: '^OPTIONS='
+    line: 'OPTIONS="-g"'
+  notify: restart ntpd
 
 - name: Add ntp preferred server
   blockinfile:
@@ -64,6 +64,14 @@
     block: "server {{ ntp_preferred }} prefer iburst"
     state: "{{ (ntp_preferred != \"\" ) | ternary('present', 'absent') }}"
   notify: restart ntpd
+  tags: ntp
+
+- name: Make sure ntp is running
+  service:
+    name: ntpd
+    state: started
+    enabled: yes
+  tags: ntp
 
 - name: Generate /etc/hosts
   blockinfile:


### PR DESCRIPTION
Ensured "-g" option is present to ensure NTP syncs regardless of time difference.
From the man page: 

Normally, ntpd exits with a message to the system log if the offset exceeds the panic threshold, which is 1000 s by default. This option allows the time to be set  to  any  value without  restriction;  however,  this can happen only once.

reordered tasks to start NTP after configuration files are created
