### PR TITLE
Update asm-create.yml

### DIFF
--- a/roles/gi-setup/tasks/asm-create.yml
+++ b/roles/gi-setup/tasks/asm-create.yml
@@ -114,3 +114,21 @@
     msg: "{{ create_dg }}"
     verbosity: 1
   tags: gi-setup,start-asm
+  
+  - name: rac-asm-create | Mount Diskgroups
+  shell: |
+    srvctl start diskgroup -diskgroup {{ item.diskgroup }}
+  environment:
+    ORACLE_HOME: "{{ grid_home }}"
+    PATH: "{{ grid_home }}/bin:${PATH}"
+    ORACLE_VERSION: "{{ oracle_ver }}"
+    ORACLE_SID: "{{ asm_sid }}"
+    LD_LIBRARY_PATH: "{{ grid_home }}/lib:${LD_LIBRARY_PATH}"
+  when: created_dg is not search('{{ item.diskgroup }}')
+  with_items:
+    - "{{ asm_disks }}"
+  register: create_dg
+  failed_when: "'ERROR' in create_dg.stdout"
+  become: yes
+  become_user: "{{ grid_user }}"
+  tags: rac-asm-create,create-dg


### PR DESCRIPTION
This role creates additional diskgroups but it doesn't mount them on other nodes, so diskgroups other than the first one created (usually data) are not mounted on nodes other than the master node. The proposed task is identical to "asm-create | (asmlib) Create disk groups" but it runs the srvctl start diskgroup command