### PR TITLE
Update ora-host tasks

### DIFF
--- a/roles/ora-host/tasks/main.yml
+++ b/roles/ora-host/tasks/main.yml
@@ -67,7 +67,6 @@
     name: "{{ oracle_required_rpms }}"
     state: present
     lock_timeout: 180
-    enablerepo: rhel-7-server-optional-rpms
   when:
     - install_os_packages|bool and ansible_os_family == 'RedHat'
     - redhat_repo.stat.exists|bool
@@ -78,7 +77,6 @@
     name: "{{ oracle_required_rpms }}"
     state: present
     lock_timeout: 180
-    enablerepo: rhui-rhel-7-server-rhui-optional-rpms
   when:
     - install_os_packages|bool and ansible_os_family == 'RedHat'
     - rh_cloud_repo.stat.exists|bool
@@ -433,3 +431,28 @@
     - "{{ listdisks }}"
   when: asm_disk_management == "asmlib"
   tags: asm-disks
+  
+  - name: (asmlib) ASM listing results
+  debug:
+    msg:
+    - "{{ item.stderr_lines }}"
+    - "{{ item.stdout_lines }}"
+  with_items:
+    - "{{ asmconfig }}"
+    - "{{ listdisks }}"
+  when: asm_disk_management == "asmlib"
+  tags: asm-disks
+
+- name: Block http to metadata 
+  iptables:
+    chain: OUTPUT
+    protocol: tcp
+    destination: 169.254.169.254
+    destination_port: "80"
+    jump: DROP
+
+- name: config iptables service
+  command: chkconfig iptables on
+
+- name: persist iptables rules
+  command: /sbin/service iptables save


### PR DESCRIPTION
The enablerepo command always fail in both RHEL and OEL. It's usually sufficient to have the Oracle Yum repository configured. Also using iptables to block http access to metadata server is an easy way to allow installing multi-node RAC without having to do any manual steps.