### PR TITLE
Update data_mounts_config.json

### DIFF
--- a/data_mounts_config.json
+++ b/data_mounts_config.json
@@ -1,18 +1,26 @@
 [
     {
         "purpose": "software",
-	"blk_device": "/dev/BOGUS",
+	"blk_device": "/dev/mapper/<WWID>",
 	"name": "u01",
+	"num": "1",
+        "start": "0%",
+        "end": "100%",
 	"fstype":"xfs",
 	"mount_point":"/u01",
-	"mount_opts":"defaults"
+	"mount_opts":"defaults",
+	"host_name":"svr001"
     },
     {
         "purpose": "diag",
-	"blk_device": "/dev/BOGUS",
-	"name": "u02",
+	"blk_device": "/dev/mapper/<WWID>",
+	"name": "u01",
+	"num": "1",
+        "start": "0%",
+        "end": "100%",
 	"fstype":"xfs",
-	"mount_point":"/u02",
-	"mount_opts":"defaults"
+	"mount_point":"/u01",
+	"mount_opts":"defaults",
+	"host_name":"svr001"
     }
 ]


### PR DESCRIPTION
Add the attributes num, start, end and host_name will allow multiple options:
1- Creating /u01 on all RAC nodes by providing the device name on each host
2- Different devices on each node could be listed to create multiple mount points (/u01 and /u02 for example)
3- One device can be used to create multiple OS partitions and create different mount points, according to the attributes num, start and end it could be specified the size of each partition and its associated mount point

The new attributes will be used by the role host-storage (updated in another pull request)