### PR TITLE
Update tasks in role host-storage

### DIFF
--- a/roles/host-storage/tasks/main.yml
+++ b/roles/host-storage/tasks/main.yml
@@ -16,10 +16,12 @@
 - name: Partition Oracle user mount devices
   parted:
     device: "{{ item.blk_device }}"
-    number: 1
+    number: "{{ item.num }}"
+    part_start: "{{ item.start }}"
+    part_end: "{{ item.end }}"
     state: present
     label: gpt
-  when: "'mapper' not in item.blk_device"
+  when: "ansible_hostname==item.host_name"
   with_items:
     - "{{ oracle_user_data_mounts }}"
   tags: ora-mounts
@@ -27,17 +29,8 @@
 - name: Add filesystem on Oracle user mount raw devices
   filesystem:
     fstype: "{{ item.fstype }}"
-    dev: "{{ item.blk_device }}1"
-  when: "'mapper' not in item.blk_device"
-  with_items:
-    - "{{ oracle_user_data_mounts }}"
-  tags: ora-mounts
-
-- name: Add filesystem on Oracle user mount LV devices
-  filesystem:
-    fstype: "{{ item.fstype }}"
-    dev: "{{ item.blk_device }}"
-  when: "'mapper' in item.blk_device"
+    dev: "{{ item.blk_device }}{{ '' if ansible_distribution == 'OracleLinux' else 'p' }}{{ item.num }}"
+  when: "ansible_hostname==item.host_name"
   with_items:
     - "{{ oracle_user_data_mounts }}"
   tags: ora-mounts
@@ -45,23 +38,11 @@
 - name: Mount Oracle user mount raw devices
   mount:
     fstype: "{{ item.fstype }}"
-    src: "{{ item.blk_device }}1"
+    src: "{{ item.blk_device }}{{ '' if ansible_distribution == 'OracleLinux' else 'p' }}{{ item.num }}"
     path: "{{ item.mount_point }}"
     opts: "{{ item.mount_opts }}"
     state: mounted
-  when: "'mapper' not in item.blk_device"
-  with_items:
-    - "{{ oracle_user_data_mounts }}"
-  tags: ora-mounts
-
-- name: Mount Oracle user mount LV devices
-  mount:
-    fstype: "{{ item.fstype }}"
-    src: "{{ item.blk_device }}"
-    path: "{{ item.mount_point }}"
-    opts: "{{ item.mount_opts }}"
-    state: mounted
-  when: "'mapper' in item.blk_device"
+  when: "ansible_hostname==item.host_name"
   with_items:
     - "{{ oracle_user_data_mounts }}"
   tags: ora-mounts


### PR DESCRIPTION
To utilize a modified data_mount_config.json a few changes to make here:

- I don't think we should use LVM here, also searching for mapper in the device string doesn't make sense because of multipath disks. 
- We will create the partition only on the host that matches the hostname in data_mount_config.json, we can create multiple partitions on the same device
- OEL adds the partition number to the device name while RHEL adds 'p' followed by partition number hence checking for the distribution to add filesystem and mount properly