### PR TITLE
Set /dev/shm to rw in fstab

### DIFF
--- a/roles/ora-host/tasks/main.yml
+++ b/roles/ora-host/tasks/main.yml
@@ -49,7 +49,7 @@
     src: tmpfs
     path: /dev/shm
     fstype: tmpfs
-    opts: rw,seclabel,nosuid,nodev
+    opts: rw,nosuid,nodev
     state: present
 
 - name: Stat RHEL7 base repo

--- a/roles/ora-host/tasks/main.yml
+++ b/roles/ora-host/tasks/main.yml
@@ -49,7 +49,7 @@
     src: tmpfs
     path: /dev/shm
     fstype: tmpfs
-    opts: ro,nosuid,nodev
+    opts: rw,seclabel,nosuid,nodev
     state: present
 
 - name: Stat RHEL7 base repo


### PR DESCRIPTION
After installation once the server reboots ASM instance won't start because we write in fstab that /dev/shm is mounted read only