### PR TITLE
Update docs to work with local Jekyll

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,6 +3,7 @@ description: Toolkit for installing and creating an initial database on Bare Met
 remote_theme: pages-themes/cayman
 plugins:
   - jekyll-remote-theme
+markdown: kramdown
 defaults:
   -
     scope:

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,11 @@
 title: bms-toolkit
 description: Toolkit for installing and creating an initial database on Bare Metal Solution
-theme: jekyll-theme-cayman
-markdown: GFM
-
+remote_theme: pages-themes/cayman
+plugins:
+  - jekyll-remote-theme
+defaults:
+  -
+    scope:
+      path: "" # an empty string here means all files in the project
+    values:
+      layout: "default"

--- a/docs/code-of-conduct.md
+++ b/docs/code-of-conduct.md
@@ -1,3 +1,7 @@
+---
+published: True
+---
+
 # Google Open Source Community Guidelines
 
 At Google, we recognize and celebrate the creativity and collaboration of open

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,3 +1,7 @@
+---
+published: True
+---
+
 # How to Contribute
 
 We'd love to accept your patches and contributions to this project. There are

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1218,7 +1218,7 @@ ORA_STAGING
 --ora-staging
 </pre></p></td>
 <td>user defined<br>
-<ORA_SWLIB_PATH></td>
+ORA_SWLIB_PATH</td>
 <td>Working area for unzipping and staging software and installation
 files.<br>
 <br>
@@ -1400,7 +1400,7 @@ COMPATIBLE_RDBMS
 --compatible-rdbms
 </pre></p></td>
 <td>user defined<br>
-<Oracle version></td>
+Oracle version</td>
 <td>Defaults to the value of ORA_VERSION.</td>
 </tr>
 <tr>

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,3 +1,7 @@
+---
+published: True
+---
+
 # Toolkit for Bare Metal Solution: User Guide
 
 ## Table of Contents


### PR DESCRIPTION
Making a few updates to permit docs to be rendered using a local Jekyll
install, allowing changes to be tested pre-commit.

There are a few components here:
- Adding yaml frontmatter --- to markdown files to tell Jekyll to
process them.  This had the side effect of adding a small table in
GitHub's view.
- Changing formatter from GFM to kramdown, which is available in vanilla
Jekyll
- Setting up an explicit default layout
- Pulling the theme directly from the upstream on build, rather than
using GitHub's built-in version
- Fixing invalid embedded HTML that was breaking kramdown parsing

The URL for contributing and code-of-conduct pages will change to have a
.html extension and be processed when viewed on GitHub pages.