### PR TITLE
Ignore errors adjusting sqlpatch objects

### DIFF
--- a/roles/patch/tasks/rac-opatch.yml
+++ b/roles/patch/tasks/rac-opatch.yml
@@ -162,7 +162,7 @@
   tags: rac-opatch
 
   # with MGMTDB installed under grid permissions should be adjusted for oracle
-- name: rac-dbpatch | Adjust sqlpatch objects
+- name: rac-opatch | Adjust sqlpatch objects
   file:
     path: "{{ item.obj_path }}"
     state: "{{ item.obj_type }}"
@@ -174,6 +174,7 @@
     - { obj_path: "{{ oracle_base }}/cfgtoollogs/sqlpatch/sqlpatch_history.txt", obj_type: "file" }
   when: apply_needed
   become: yes
+  ignore_errors: true
   tags: patch_rdbms,datapatch
 
 - name: rac-opatch | Remove db_state.out if it exists


### PR DESCRIPTION
On a never-patched system, {{ oracle_base }}/cfgtoollogs/sqlpatch/sqlpatch_history.txt doesn't exist.  Rather than failing in this case, ignore the error and continue.