### PR TITLE
The boolean check in `rac-lsnr-firewall` is incorrect .

### DIFF
--- a/roles/rac-lsnr-firewall/tasks/main.yml
+++ b/roles/rac-lsnr-firewall/tasks/main.yml
@@ -24,7 +24,7 @@
   failed_when:
     - "'firewall is not currently running' not in firewall_output.msg"
     - "'Permanent and Non-Permanent(immediate) operation' not in firewall_output.msg"
-  when: disable_firewall|bool is false
+  when: not disable_firewall|bool
   tags: lsnr-firewall
 
 - name: Test whether port is free


### PR DESCRIPTION
The boolean check in `rac-lsnr-firewall` is incorrect .

```
---
- name: Open listener port in firewall
 firewalld:
   port: "{{ hostvars[groups['dbasm'].0]['scan_port'] }}/tcp"
   permanent: yes
   immediate: yes
   state: enabled
 become: yes
 register: firewall_output
 failed_when:
   - "'firewall is not currently running' not in firewall_output.msg"
   - "'Permanent and Non-Permanent(immediate) operation' not in firewall_output.msg"
 when: disable_firewall|bool is false  ⇐==================
 tags: lsnr-firewall

```

Error received:
```
TASK [rac-lsnr-firewall : Open listener port in firewall] **********************
fatal: [at-00010-svr002]: FAILED! => {"msg": "The conditional check 'disable_firewall|bool is false' failed. The error was: template error while templating string: no test named 'false'. String: {% if disable_firewall|bool is false %} True {% else %} False {% endif %}\n\nThe error appears to be in '/home/jcnarasimhan/041921/bms-toolkit/roles/rac-lsnr-firewall/tasks/main.yml': line 16, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n---\n- name: Open listener port in firewall\n  ^ here\n"}

2021-04-21 09:21:40,596 p=29868 u=jcnarasimhan n=ansible | fatal: [at-00010-svr002]: FAILED! => {"msg": "The conditional check 'disable_firewall|bool is false' failed. The error was: template error while templating string: no test named 'false'. String: {% if disable_firewall|bool is false %} True {% else %} False {% endif %}

The error appears to be in '/home/jcnarasimhan/041921/bms-toolkit/roles/rac-lsnr-firewall/tasks/main.yml': line 16, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

---
- name: Open listener port in firewall
  ^ here
"}

```

Fix:
```
---
- name: Open listener port in firewall
  firewalld:
    port: "{{ hostvars[groups['dbasm'].0]['scan_port'] }}/tcp"
    permanent: yes
    immediate: yes
    state: enabled
  become: yes
  register: firewall_output
  failed_when:
    - "'firewall is not currently running' not in firewall_output.msg"
    - "'Permanent and Non-Permanent(immediate) operation' not in firewall_output.msg"
  when: not disable_firewall|bool   <=================
  tags: lsnr-firewall
```