### PR TITLE
Create a GitHub action to save repo statistics

### DIFF
--- a/.github/workflows/export-stats.yml
+++ b/.github/workflows/export-stats.yml
@@ -1,0 +1,31 @@
+# Save traffic statistics beyond GitHub's 14-day retention thanks to sangonzal/repository-traffic-action
+name: Export Stats
+
+on:
+  schedule:
+    - cron: '30 23 * * 0'
+  workflow_dispatch:
+
+jobs:
+  traffic:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Set up gcloud / gsutil
+      uses: google-github-actions/setup-gcloud@master
+      with:
+        service_account_key: ${{ secrets.GCS_SA_KEY }}
+        project_id: ${{ secrets.GCS_PROJECT }}
+        export_default_credentials: true
+    - name: Create traffic dir
+      run: mkdir -p traffic/
+    - name: Download existing files
+      run: |-
+        gsutil rsync gs://${{ secrets.GCS_BUCKET }}/ traffic/
+    - name: Calculate traffic and save results in traffic/
+      uses: sangonzal/repository-traffic-action@master
+      env:
+        TRAFFIC_ACTION_TOKEN: ${{ secrets.STATS_TOKEN }} 
+    - name: Upload results to GCS
+      run: |-
+        gsutil rsync traffic/ gs://${{ secrets.GCS_BUCKET }}/


### PR DESCRIPTION
Makes use of sangonzal/repository-traffic-action in a GitHub action to collect and repository usage statistics beyond the 14 days that GitHub's own traffic API shows.