### PR TITLE
firewall settings needed for inter-node communication

### DIFF
--- a/install-sw.yml
+++ b/install-sw.yml
@@ -53,6 +53,9 @@
     - name: rac-gi-install | defaults from common
       include_vars:
         dir: roles/common/defaults
+    - name: rac-gi-install | open firewall
+      include_role:
+        name: rac-lsnr-firewall
     - name: rac-gi-install | setup ssh keys
       include_role:
         name: ssh-setup
@@ -72,9 +75,9 @@
     - name: rac-gi-install | defaults from common
       include_vars:
         dir: roles/common/defaults
-    - name: rac-gi-install | open firewall
-      include_role:
-        name: rac-lsnr-firewall
+  #  - name: rac-gi-install | open firewall
+  #    include_role:
+  #      name: rac-lsnr-firewall
     - name: rac-gi-install | GI installation
       include_role:
         name: rac-gi-setup

--- a/install-sw.yml
+++ b/install-sw.yml
@@ -47,6 +47,7 @@
        - cluster_type in ("NONE", "DG")
   tags: rdbms-setup
 
+
 - hosts: dbasm
   serial: 1
   tasks:
@@ -56,6 +57,16 @@
     - name: rac-gi-install | open firewall
       include_role:
         name: rac-lsnr-firewall
+      when:
+        - cluster_type == "RAC"
+  tags: lsnr-firewall
+
+- hosts: dbasm
+  serial: 1
+  tasks:
+    - name: rac-gi-install | defaults from common
+      include_vars:
+        dir: roles/common/defaults
     - name: rac-gi-install | setup ssh keys
       include_role:
         name: ssh-setup
@@ -75,9 +86,6 @@
     - name: rac-gi-install | defaults from common
       include_vars:
         dir: roles/common/defaults
-  #  - name: rac-gi-install | open firewall
-  #    include_role:
-  #      name: rac-lsnr-firewall
     - name: rac-gi-install | GI installation
       include_role:
         name: rac-gi-setup

--- a/install-sw.yml
+++ b/install-sw.yml
@@ -49,7 +49,6 @@
 
 
 - hosts: dbasm
-  serial: 1
   tasks:
     - name: rac-gi-install | defaults from common
       include_vars:

--- a/roles/rac-lsnr-firewall/tasks/main.yml
+++ b/roles/rac-lsnr-firewall/tasks/main.yml
@@ -53,6 +53,11 @@
     immediate: yes
     state: enabled
   become: yes
+  register: firewall_op_localnw
+  failed_when:
+    - "'firewall is not currently running' not in firewall_op_localnw.msg"
+    - "'Permanent and Non-Permanent(immediate) operation' not in firewall_op_localnw.msg"
+  when: not disable_firewall|bool
   with_items:
     - "{{ ansible_facts | dict2items | selectattr('value.ipv4.network', 'defined') |list }}"
   tags: lsnr-firewall
@@ -65,4 +70,9 @@
     immediate: yes
     state: enabled
   become: yes
+  register: firewall_op_haipnw
+  failed_when:
+    - "'firewall is not currently running' not in firewall_op_haipnw.msg"
+    - "'Permanent and Non-Permanent(immediate) operation' not in firewall_op_haipnw.msg"
+  when: not disable_firewall|bool
   tags: lsnr-firewall

--- a/roles/rac-lsnr-firewall/tasks/main.yml
+++ b/roles/rac-lsnr-firewall/tasks/main.yml
@@ -45,3 +45,24 @@
   when: create_listener
   tags: lsnr-firewall
 
+- name: Allow local networks for RAC
+  firewalld:
+    zone: public
+    rich_rule: rule family=ipv4 source address="{{ item.value.ipv4.network }}/{{ item.value.ipv4.netmask}}" accept
+    permanent: yes
+    immediate: yes
+    state: enabled
+  become: yes
+  with_items:
+    - "{{ ansible_facts | dict2items | selectattr('value.ipv4.network', 'defined') |list }}"
+  tags: lsnr-firewall
+
+- name: Allow HAIP networks
+  firewalld:
+    zone: public
+    rich_rule: rule family=ipv4 source address="169.254.0.0/16" accept
+    permanent: yes
+    immediate: yes
+    state: enabled
+  become: yes
+  tags: lsnr-firewall


### PR DESCRIPTION
As posted earlier in https://github.com/google/bms-toolkit/pull/59#issuecomment-843243674, creating this PR, with both solutions based on Marc's snippets (from his experimental cs) tested successfully on OEL 7.9 BMS hosts.

Following sections detail each Ansible block's justification with error / resolution details:
####################### 
Reproduction of errors due to network firewall in BMS hosts running OEL7.9.

##### Error and resolution of opening up hosts in firewall:

```
[grid@mntrl-host2 ~]$ /u01/app/19.3.0/grid/gridSetup.sh -silent -responseFile /u01/app/19.3.0/grid/gridsetup.rsp   -J-Doracle.install.mgmtDB=false -J-Doracle.install.mgmtDB.CDB=false -J-Doracle.install.crs.enableRemoteGIMR=false -ignorePrereqFailure
Launching Oracle Grid Infrastructure Setup Wizard...

[FATAL] [INS-41116] Installer has detected that the selected following nodes do not have connectivity with other cluster nodes through the selected interface. 
 [[]]. 
 
 These nodes will be ignored and not participate in the configured Grid Infrastructure.
*ADDITIONAL INFORMATION:*
Summary of node specific errors
mntrl-host1
mntrl-host2
 - PRVG-11067 : TCP connectivity from node "mntrl-host2": "172.16.110.1" to node "mntrl-host1": "172.16.110.2" failed. PRVG-11095 : The TCP system call "connect" failed with error "113" while executing exectask on node "mntrl-host2" No route to host
 - Cause:  Errors occurred while attempting to establish Transmission Control Protocol (TCP) connectivity between the identified two interfaces.
 - Action:  Ensure that there are no firewalls blocking TCP operations and no process monitors running that can interfere with programs'' network operations.
```

was resolved by adding this into rac_lsnr_firewall/tasks/main.yml:
```
- hosts: all
 become: true
 tasks:
   - name: Allow local networks for RAC
     firewalld:
       zone: public
       rich_rule: rule family=ipv4 source address="{{ item.value.ipv4.network }}/{{ item.value.ipv4.netmask}}" accept
       state: enabled
       immediate: yes
       permanent: true
     with_items:
       - "{{ ansible_facts | dict2items | selectattr('value.ipv4.network', 'defined') |list }}"
```

And then, calling that block to run on both nodes in install-sw.yml, like below:
```
- hosts: dbasm
  serial: 1
  tasks:
    - name: rac-gi-install | defaults from common
      include_vars:
        dir: roles/common/defaults
    - name: rac-gi-install | open firewall
      include_role:
        name: rac-lsnr-firewall
```


##### Error and resolution of opening up HAIP addresses:

Following error...:
```
            "[FATAL] PRCR-1079 : Failed to start resource ora.orcl.db", 
            "ORA-03113: end-of-file on communication channel", 
            "Process ID: 0", 
            "Session ID: 0 Serial number: 0", 
            "", 
            "CRS-2674: Start of 'ora.asm' on 'at-3793329-svr006' failed", 
            "ORA-03113: end-of-file on communication channel", 
            "Process ID: 0", 
            "Session ID: 0 Serial number: 0", 
            "", 
            "CRS-2674: Start of 'ora.asm' on 'at-3793329-svr006' failed", 
            "CRS-5017: The resource action \"ora.orcl.db start\" encountered the following error: ", 
            "ORA-03113: end-of-file on communication channel", 
            "Process ID: 0", 
            "Session ID: 0 Serial number: 0", 
            ". For details refer to \"(:CLSN00107:)\" in \"/u01/app/oracle/diag/crs/at-3793329-svr005/crs/trace/crsd_oraagent_oracle.trc\".", 
            "", 
            "CRS-2674: Start of 'ora.orcl.db' on 'at-3793329-svr005' failed", 
            "67% complete", 

```

matched with this metalink note:
`Only One Instance of a RAC Database Can Start at a Time: Second Instance Fails to Start due to "No reconfig messages from other instances" - LMON is terminating the instance (Doc ID 2528588.1)`


Our snippets:
from alert log: /u01/app/oracle/diag/rdbms/orcl/orcl1/trace/alert_orcl1.log
```
   2110 Cluster Communication is configured to use IPs from: GPnP
   2111 IP: 169.254.24.169       Subnet: 169.254.0.0
...
   2268 No connectivity to other instances in the cluster during startup. Hence, LMON is terminating the instance. Please check the LMON trace file for details. Also, please ch        eck the network logs of this instance along with clusterwide network health for problems and then re-start this instance.
   2269 LMON (ospid: ): terminating the instance due to ORA error
   2270 Cause - 'Instance is being terminated by LMON'   
```


from lmon trc file: /u01/app/oracle/diag/rdbms/orcl/orcl1/trace/orcl1_lmon_19696.trc:
```
  170 *** 2021-05-13T20:14:28.294209-07:00
    171 IPCLW:[0.41]{E}[WAIT]:PROTO: [1620962068294072]RETRANS DBG local acnh 0x7f2eae398ab0 dump:
    172 IPCLW:[0.42]{-}[WAIT]:UTIL: [1620962068294072]  ACNH 0x7f2eae398ab0 State: 1 SMSN: 987049026 PKT(987049027.734422451) # Pending: 1
    173 IPCLW:[0.43]{-}[WAIT]:UTIL: [1620962068294072]   Peer: LMON.KSXP_cgs.19981 AckSeq: 734422450
    174 IPCLW:[0.44]{-}[WAIT]:UTIL: [1620962068294072]   Flags: 0x00000000 IHint: 0x700a68060000001f THint: 0x713cf1d0000001f
    175 IPCLW:[0.45]{-}[WAIT]:UTIL: [1620962068294072]   Local Address: 169.254.24.169:59825 Remote Address: 169.254.26.248:63753
    176 IPCLW:[0.46]{-}[WAIT]:UTIL: [1620962068294072]   Remote PID: ver 0 flags 1 trans 2 tos 0 opts 0 xdata3 1be7 xdata2 9edd2d5c
    177 IPCLW:[0.47]{-}[WAIT]:UTIL: [1620962068294072]             : mmsz 32768 mmr 4096 mms 4096 xdata c2413228
    178 IPCLW:[0.48]{-}[WAIT]:UTIL: [1620962068294072]   IVPort: 4084 TVPort: 12840 IMPT: 52849 RMPT: 7143   Pending Sends: Yes Unacked Sends: Yes
    179 IPCLW:[0.49]{-}[WAIT]:UTIL: [1620962068294072]   Send Engine Queued: No sshdl -1 ssts 0 rtts 1620962068294188 snderrchk 4 creqcnt 2 credits 7/8
    180 IPCLW:[0.50]{-}[WAIT]:UTIL: [1620962068294072]   Unackd Messages 987049026 -> 987049026. SSEQ 734422450 Send Time: 0:0:25.744.744074 SMSN # Xmits: 256 EMSN 0:0:25.744.7        44074
    181 IPCLW:[0.51]{-}[WAIT]:UTIL: [1620962068294072]  Pending send queue:
...


    358 
    359 No reconfig messages from other instances in the cluster during startup. Hence, LMON is terminating the instance. Please check the network logs of this instance as well         as the network health of the cluster for problems or if the GI is in patching mode
```

Direct matches to snippets in 2528588.1.

This was resolved by reusing snippets from Marc's experimental:
```
   - name: Allow HAIP networks
     firewalld:
       zone: public
       rich_rule: rule family=ipv4 source address="169.254.0.0/19" accept
       state: enabled
       immediate: yes
       permanent: true
```

##### Summary:
* CRS IPs get plumbed on pvt. i/c by the clusterware.
    * 169.254.x.x IPs on the private NIC (bond1.106) as <bond1.106:1>
* This IP is used by HAIP and shows up in gv$cluster_interconnect
* HAIP summary in 2 lines: (ref: 1210883.1): 
    * The 169.254.x.x link local IP is the HAIP and it’s configured on 1 or more physical NICs. If one of the NICs is shot, the IP moves over to the other NIC.
* Reason LMON kills the other instance is that it’s not able to receive heartbeats from the other instance via the configured cluster_interconnect.
* Summary of all code changes to fix this:

   * roles/rac_lsnr_firewall/tasks/main.yml:
```
- hosts: all
 become: true
 tasks:
   - name: Allow local networks for RAC
     firewalld:
       zone: public
       rich_rule: rule family=ipv4 source address="{{ item.value.ipv4.network }}/{{ item.value.ipv4.netmask}}" accept
       state: enabled
       immediate: yes
       permanent: true
     with_items:
       - "{{ ansible_facts | dict2items | selectattr('value.ipv4.network', 'defined') |list }}"
       
   - name: Allow HAIP networks
     firewalld:
       zone: public
       rich_rule: rule family=ipv4 source address="169.254.0.0/19" accept
       state: enabled
       immediate: yes
       permanent: true
```

And then, calling that block to run on both nodes in install-sw.yml, like below:
```
- hosts: dbasm
  serial: 1
  tasks:
    - name: rac-gi-install | defaults from common
      include_vars:
        dir: roles/common/defaults
    - name: rac-gi-install | open firewall
      include_role:
        name: rac-lsnr-firewall
```



