### PR TITLE
rpm related config changes tested successfully for OEL 7.9

### DIFF
--- a/roles/ora-host/tasks/main.yml
+++ b/roles/ora-host/tasks/main.yml
@@ -62,29 +62,31 @@
     path: /etc/yum.repos.d/rh-cloud.repo
   register: rh_cloud_repo
 
-- name: Install Oracle required packages (base/non-rhui config) for RHEL
+- name: Install Oracle required packages (base/non-rhui config) for RHEL7
   yum:
     name: "{{ oracle_required_rpms }}"
     state: present
     lock_timeout: 180
     enablerepo: rhel-7-server-optional-rpms
   when:
-    - install_os_packages|bool and ansible_os_family == 'RedHat' and ansible_distribution == 'RedHat'
+    - install_os_packages|bool and ansible_distribution == 'RedHat'
     - redhat_repo.stat.exists|bool
   tags: os-packages
 
-- name: Stat OEL7 repo
+- name: Stat OL7 repo
   stat:
     path: /etc/yum.repos.d/oracle-linux-ol7.repo
   register: oraclelinux_repo
+  when:
+    - install_os_packages|bool and ansible_distribution == 'OracleLinux'
 
-- name: Install Oracle required packages (base/non-rhui config) for OEL
+- name: Install Oracle required packages (base/non-rhui config) for OEL7
   yum:
     name: "{{ oracle_required_rpms }}"
     state: present
     lock_timeout: 180
   when:
-    - install_os_packages|bool and ansible_os_family == 'RedHat' and ansible_distribution == 'OracleLinux'
+    - install_os_packages|bool and ansible_distribution == 'OracleLinux'
     - oraclelinux_repo.stat.exists|bool
   tags: os-packages
 

--- a/roles/ora-host/tasks/main.yml
+++ b/roles/ora-host/tasks/main.yml
@@ -62,15 +62,30 @@
     path: /etc/yum.repos.d/rh-cloud.repo
   register: rh_cloud_repo
 
-- name: Install Oracle required packages (base/non-rhui config)
+- name: Install Oracle required packages (base/non-rhui config) for RHEL
   yum:
     name: "{{ oracle_required_rpms }}"
     state: present
     lock_timeout: 180
     enablerepo: rhel-7-server-optional-rpms
   when:
-    - install_os_packages|bool and ansible_os_family == 'RedHat'
+    - install_os_packages|bool and ansible_os_family == 'RedHat' and ansible_distribution == 'RedHat'
     - redhat_repo.stat.exists|bool
+  tags: os-packages
+
+- name: Stat OEL7 repo
+  stat:
+    path: /etc/yum.repos.d/oracle-linux-ol7.repo
+  register: oraclelinux_repo
+
+- name: Install Oracle required packages (base/non-rhui config) for OEL
+  yum:
+    name: "{{ oracle_required_rpms }}"
+    state: present
+    lock_timeout: 180
+  when:
+    - install_os_packages|bool and ansible_os_family == 'RedHat' and ansible_distribution == 'OracleLinux'
+    - oraclelinux_repo.stat.exists|bool
   tags: os-packages
 
 - name: Install Oracle required packages (rhui config)

--- a/roles/ora-host/tasks/main.yml
+++ b/roles/ora-host/tasks/main.yml
@@ -69,7 +69,7 @@
     lock_timeout: 180
     enablerepo: rhel-7-server-optional-rpms
   when:
-    - install_os_packages|bool and ansible_distribution == 'RedHat'
+    - install_os_packages|bool and ansible_distribution == 'RedHat' and ansible_distribution_major_version == '7'
     - redhat_repo.stat.exists|bool
   tags: os-packages
 
@@ -86,7 +86,7 @@
     state: present
     lock_timeout: 180
   when:
-    - install_os_packages|bool and ansible_distribution == 'OracleLinux'
+    - install_os_packages|bool and ansible_distribution == 'OracleLinux' and ansible_distribution_major_version == '7'
     - oraclelinux_repo.stat.exists|bool
   tags: os-packages
 
@@ -97,7 +97,7 @@
     lock_timeout: 180
     enablerepo: rhui-rhel-7-server-rhui-optional-rpms
   when:
-    - install_os_packages|bool and ansible_os_family == 'RedHat'
+    - install_os_packages|bool and ansible_distribution_major_version == '7'
     - rh_cloud_repo.stat.exists|bool
     - not redhat_repo.stat.exists|bool
   tags: os-packages


### PR DESCRIPTION
As commented in: https://github.com/google/bms-toolkit/pull/60#discussion_r634493544 , creating this PR for OEL 7 rpm config changes.
 in OEL7.9, I was able to simulate missing rpms and fix it.
There was a logical error in the above snippet in my prior update in the `when` clause for OEL.

The correct block that was tested successfully is as follows:
```
- name: Install Oracle required packages (base/non-rhui config) for RHEL
  yum:
    name: "{{ oracle_required_rpms }}"
    state: present
    lock_timeout: 180
    enablerepo: rhel-7-server-optional-rpms
  when:
    - install_os_packages|bool and ansible_os_family == 'RedHat' and ansible_distribution == 'RedHat'
    - redhat_repo.stat.exists|bool
  tags: os-packages

- name: Stat OEL7 repo
  stat:
    path: /etc/yum.repos.d/oracle-linux-ol7.repo
  register: oraclelinux_repo

- name: Install Oracle required packages (base/non-rhui config) for OEL
  yum:
    name: "{{ oracle_required_rpms }}"
    state: present
    lock_timeout: 180
  when:
    - install_os_packages|bool and ansible_os_family == 'RedHat' and ansible_distribution == 'OracleLinux'
    - oraclelinux_repo.stat.exists|bool
  tags: os-packages

```

Additional notes (internal): https://docs.google.com/document/d/1mX59YHO37MavCGmfLlTtEmitRc53oeYkEgU3PtYMbrg/edit?usp=sharing