### PR TITLE
Zero out entire user data disk in cleanup

### DIFF
--- a/roles/brute-ora-cleanup/tasks/main.yml
+++ b/roles/brute-ora-cleanup/tasks/main.yml
@@ -191,15 +191,14 @@
 - name: Zero-out header in Oracle user data disks
   become: yes
   become_user: root
-  command: "dd if=/dev/zero of={{ item.blk_device }}1 bs=1M count=100"
+  command: "dd if=/dev/zero of={{ item.blk_device }} bs=1M count=100"
   with_items:
     - "{{ oracle_user_data_mounts }}"
 
-- name: Delete partition Oracle user data devices
-  parted:
-    device: "{{ item.blk_device }}"
-    number: 1
-    state: absent
+- name: Reload partition table for user data disks
+  become: yes
+  become_user: root
+  command: "partprobe {{ item.blk_device }}"
   with_items:
     - "{{ oracle_user_data_mounts }}"
 


### PR DESCRIPTION
The existing zero-out logic appends "1" to the device name;  but if the device has no partitions, it results in a nonexistant device and the disk is not zeroed out at all.  Modifying the logic to unconditionally zero out the the first 100mb of the raw device, which covers both the partition table and any filesystem headers.  Then run partprobe to allow the kernel to clean up former partition devices, if any.