### PR TITLE
Update Jinja and style on backup scripts

### DIFF
--- a/roles/db-backups/templates/rman_arch_backup.sh.j2
+++ b/roles/db-backups/templates/rman_arch_backup.sh.j2
@@ -11,6 +11,9 @@ ts="date +%Y-%m-%d_%H-%M-%S"             # Timestamp format
 start_ts="$($ts)"                        # Start timestamp
 log_dir="{{ logs_dir }}"                 # A directory for the logs
 type="ARCH"                              # Type is archivelog backup
+conn_str="{% if oracle_ver == "11.2.0.4.0" %}/{% else %}/ AS SYSBACKUP{% endif %}" # Oracle connection string
+backup_dest="{{ backup_dest }}"          # Backup destination path
+reco_diskgroup="+{{ reco_diskgroup }}"   # Fast recovery area diskgroup
 export NLS_DATE_FORMAT="YYYY-MM-DD HH24:MI:SS"
 #
 if [[ $# -ne 3 ]]; then
@@ -34,18 +37,13 @@ logfile="${log_dir}/rman_${start_ts}_${type}.log"
 if "${ORACLE_HOME}/bin/rman" >> "${outfile}" << EOF
   set echo on
   spool log to '${logfile}'
-  connect target {% if oracle_ver == "11.2.0.4.0" %}'/'{% else %}'/ AS SYSBACKUP'{% endif %}
+  connect target '${conn_str}'
 
   configure controlfile autobackup on;
   configure device type disk parallelism 4;
-  {% if backup_dest[0:1]  == "/" %}
-  configure controlfile autobackup format for device type disk to '{{ backup_dest }}/${ora_inst_name}_%F';
-  configure channel device type disk format '{{ backup_dest }}/${ora_inst_name}_${type}_%U';
-  {% else %}
-  configure controlfile autobackup format for device type disk to '{{ backup_dest }}';
-  configure channel device type disk format '{{ backup_dest }}';
-  {% endif %}
-  configure snapshot controlfile name to '+{{ reco_diskgroup }}/{{ db_name }}/snapcf_{{ db_name }}.f';
+  configure controlfile autobackup format for device type disk to '${autobackup_format}';
+  configure channel device type disk format '${channel_format}';
+  configure snapshot controlfile name to '${reco_diskgroup}/snapcf_${ora_inst_name}.f';
   configure archivelog deletion policy to backed up ${arch_redundancy} times to disk;
   run {
     crosscheck archivelog all;
@@ -58,11 +56,11 @@ EOF
 # Return code management
 #
 then
-  printf "\n\t%s\n" "INFO -- $($ts) -- ${type} backup of database {{ db_name }} has been completed successfully."
+  printf "\n\t%s\n" "INFO -- $($ts) -- ${type} Level ${rman_level} of instance ${ora_inst_name} has been completed successfully."
   printf "\t%s\n\n" "INFO -- $($ts) -- logfile used by this session: ${logfile}"
   ret_code=0
 else
-  printf "\n\t%s\n\n" "ERROR -- $($ts) --  ${type} backup of database {{ db_name }} had errors, please have a look at the logfile: ${logfile}"
+  printf "\n\t%s\n\n" "ERROR -- $($ts) --  ${type} Level ${rman_level} of instance ${ora_inst_name} had errors, please have a look at the logfile: ${logfile}"
   ret_code=123
 fi
 exit ${ret_code}

--- a/roles/db-backups/templates/rman_arch_backup.sh.j2
+++ b/roles/db-backups/templates/rman_arch_backup.sh.j2
@@ -32,6 +32,25 @@ source oraenv <<< "${ora_inst_name}" > /dev/null 2>&1
 outfile="${log_dir}/rman_${start_ts}_${type}.out"
 logfile="${log_dir}/rman_${start_ts}_${type}.log"
 #
+# Check if $log_dir exists; if not, we create it
+#
+if [[ ! -d "${log_dir}" ]]; then
+  if mkdir -p "${log_dir}"; then
+    printf "\n\t%s\n\n" "INFO -- $($ts) -- ${log_dir} successfully created."
+  else
+    printf "\n\t%s\n\n" "ERROR -- $($ts) -- Impossible to create ${log_dir}; we wont be able to log this backup."
+  fi
+fi
+if [[ $backup_dest == "/"* ]]; then
+  # Filesystem destination
+  autobackup_format="${backup_dest}/${ora_inst_name}_%F"
+  channel_format="${backup_dest}/${ora_inst_name}_${type}_level_${rman_level}_%U"
+else
+  # ASM destination;  no need for format specifiers
+  autobackup_format="${backup_dest}"
+  channel_format="${backup_dest}"
+fi
+#
 # Do the backup
 #
 if "${ORACLE_HOME}/bin/rman" >> "${outfile}" << EOF

--- a/roles/db-backups/templates/rman_arch_backup.sh.j2
+++ b/roles/db-backups/templates/rman_arch_backup.sh.j2
@@ -4,28 +4,34 @@
 #
 # Variables
 #
-         ORA_INST_NAME=${1}
-       ARCH_REDUNDANCY=${2}
-      ARCH_DAYS_ONLINE=${3}
-                    TS="date +%Y-%m-%d_%H-%M-%S"        # A timestamp
-                A_DATE=$($TS)                           # The current date
-               LOG_DIR='{{ logs_dir }}'                 # A directory for the logs
-                  TYPE="ARCH"                           # Type is archivelog backup
-export NLS_DATE_FORMAT="DD/MM/YYYY HH24:MI:SS"          # A nice date format for the RMAN logs
+ora_inst_name=${1}
+arch_redundancy=${2}
+arch_day_online=${3}
+ts="date +%Y-%m-%d_%H-%M-%S"             # Timestamp format
+start_ts="$($ts)"                        # Start timestamp
+log_dir="{{ logs_dir }}"                 # A directory for the logs
+type="ARCH"                              # Type is archivelog backup
+export NLS_DATE_FORMAT="YYYY-MM-DD HH24:MI:SS"
+#
+if [[ $# -ne 3 ]]; then
+  echo "Usage: $0 ora_inst_name arch_redundancy arch_day_online" >&1
+  exit 1
+fi
+
 #
 # Set the Oracle env
 #
-export ORACLE_SID=${ORA_INST_NAME}
-. oraenv <<< ${ORA_INST_NAME} > /dev/null 2>&1
+export ORACLE_SID="${ora_inst_name}"
+source oraenv <<< "${ora_inst_name}" > /dev/null 2>&1
 #
 # We can now build the output file and logfile names
 #
-outfile="${LOG_DIR}/rman_${A_DATE}_${TYPE}.out"
-logfile="${LOG_DIR}/rman_${A_DATE}_${TYPE}.log"
+outfile="${log_dir}/rman_${start_ts}_${type}.out"
+logfile="${log_dir}/rman_${start_ts}_${type}.log"
 #
 # Do the backup
 #
-${ORACLE_HOME}/bin/rman >> ${outfile} << EOF
+if "${ORACLE_HOME}/bin/rman" >> "${outfile}" << EOF
   set echo on
   spool log to '${logfile}'
   connect target {% if oracle_ver == "11.2.0.4.0" %}'/'{% else %}'/ AS SYSBACKUP'{% endif %}
@@ -33,33 +39,33 @@ ${ORACLE_HOME}/bin/rman >> ${outfile} << EOF
   configure controlfile autobackup on;
   configure device type disk parallelism 4;
   {% if backup_dest[0:1]  == "/" %}
-  configure controlfile autobackup format for device type disk to '{{ backup_dest }}/${ORA_INST_NAME}_%F';
-  configure channel device type disk format '{{ backup_dest }}/${ORA_INST_NAME}_${TYPE}_%U';
+  configure controlfile autobackup format for device type disk to '{{ backup_dest }}/${ora_inst_name}_%F';
+  configure channel device type disk format '{{ backup_dest }}/${ora_inst_name}_${type}_%U';
   {% else %}
   configure controlfile autobackup format for device type disk to '{{ backup_dest }}';
   configure channel device type disk format '{{ backup_dest }}';
   {% endif %}
   configure snapshot controlfile name to '+{{ reco_diskgroup }}/{{ db_name }}/snapcf_{{ db_name }}.f';
-  configure archivelog deletion policy to backed up ${ARCH_REDUNDANCY} times to disk;
+  configure archivelog deletion policy to backed up ${arch_redundancy} times to disk;
   run {
     crosscheck archivelog all;
-    backup check logical archivelog all not backed up ${ARCH_REDUNDANCY} times;
-    delete noprompt archivelog all backed up ${ARCH_REDUNDANCY} times to disk completed before 'SYSDATE-${ARCH_DAYS_ONLINE}';
+    backup check logical archivelog all not backed up ${arch_redundancy} times;
+    delete noprompt archivelog all backed up ${arch_redundancy} times to disk completed before 'SYSDATE-${arch_day_online}';
   }
   spool log off
 EOF
 #
 # Return code management
 #
-if [ $? = 0 ]; then
-  printf "\n\t%s\n" "INFO -- $($TS) -- ${TYPE} backup of database {{ db_name }} has been completed successfully."
-  printf "\t%s\n\n" "INFO -- $($TS) -- logfile used by this session: ${logfile}."
-  RET_CODE=0
+then
+  printf "\n\t%s\n" "INFO -- $($ts) -- ${type} backup of database {{ db_name }} has been completed successfully."
+  printf "\t%s\n\n" "INFO -- $($ts) -- logfile used by this session: ${logfile}"
+  ret_code=0
 else
-  printf "\n\t%s\n\n" "ERROR -- $($TS) --  ${TYPE} backup of database {{ db_name }} had errors, please have a look at the logfile: ${logfile}."
-  RET_CODE=123
+  printf "\n\t%s\n\n" "ERROR -- $($ts) --  ${type} backup of database {{ db_name }} had errors, please have a look at the logfile: ${logfile}"
+  ret_code=123
 fi
-exit ${RET_CODE}
+exit ${ret_code}
 #
 #****************************************************************************************#
 #                       E N D      O F       S O U R C E                                *#

--- a/roles/db-backups/templates/rman_full_backup.sh.j2
+++ b/roles/db-backups/templates/rman_full_backup.sh.j2
@@ -9,6 +9,9 @@ arch_redundancy=${4}                     # Archivelog redundancy
 ts="date +%Y-%m-%d_%H-%M-%S"             # Timestamp format
 start_ts="$($ts)"                        # Start timestamp
 log_dir="{{ logs_dir }}"                 # A directory for the logs
+conn_str="{% if oracle_ver == "11.2.0.4.0" %}/{% else %}/ AS SYSBACKUP{% endif %}" # Oracle connection string
+backup_dest="{{ backup_dest }}"          # Backup destination path
+reco_diskgroup="+{{ reco_diskgroup }}"   # Fast recovery area diskgroup
 export NLS_DATE_FORMAT="YYYY-MM-DD HH24:MI:SS"
 #
 if [[ $# -ne 4 ]]; then
@@ -33,6 +36,15 @@ if [[ ! -d "${log_dir}" ]]; then
     printf "\n\t%s\n\n" "ERROR -- $($ts) -- Impossible to create ${log_dir}; we wont be able to log this backup."
   fi
 fi
+if [[ $backup_dest == "/"* ]]; then
+  # Filesystem destination
+  autobackup_format="${backup_dest}/${ora_inst_name}_%F"
+  channel_format="${backup_dest}/${ora_inst_name}_${type}_level_${rman_level}_%U"
+else
+  # ASM destination;  no need for format specifiers
+  autobackup_format="${backup_dest}"
+  channel_format="${backup_dest}"
+fi
 #
 # We can now build the output file and logfile names
 #
@@ -49,19 +61,14 @@ source oraenv <<< "${ora_inst_name}" > /dev/null 2>&1
 if "${ORACLE_HOME}/bin/rman" >> "${outfile}" << EOF
   set echo on
   spool log to '${logfile}'
-  connect target {% if oracle_ver == "11.2.0.4.0" %}'/'{% else %}'/ AS SYSBACKUP'{% endif %}
+  connect target '${conn_str}'
 
   configure controlfile autobackup on;
   configure device type disk parallelism 4;
 
-  {% if backup_dest[0:1]  == "/" %}
-  configure controlfile autobackup format for device type disk to '{{ backup_dest }}/${ora_inst_name}_%F';
-  configure channel device type disk format '{{ backup_dest }}/${ora_inst_name}_${type}_Level_${rman_level}_%U';
-  {% else %}
-  configure controlfile autobackup format for device type disk to '{{ backup_dest }}';
-  configure channel device type disk format '{{ backup_dest }}';
-  {% endif %}
-  configure snapshot controlfile name to '+{{ reco_diskgroup }}/{{ db_name }}/snapcf_{{ db_name }}.f';
+  configure controlfile autobackup format for device type disk to '${autobackup_format}';
+  configure channel device type disk format '${channel_format}';
+  configure snapshot controlfile name to '${reco_diskgroup}/snapcf_${ora_inst_name}.f';
 
   configure archivelog deletion policy to backed up ${arch_redundancy} times to disk;
   configure retention policy to redundancy ${retention_redundancy};
@@ -85,11 +92,11 @@ EOF
 # Success or error output with the name of the logfile
 #
 then
-  printf "\n\t%s\n" "INFO -- $($ts) -- ${type} Level ${rman_level} of database {{ db_name }} has been completed successfully."
+  printf "\n\t%s\n" "INFO -- $($ts) -- ${type} Level ${rman_level} of instance ${ora_inst_name} has been completed successfully."
   printf "\t%s\n\n" "INFO -- $($ts) -- logfile used by this session: ${logfile}"
   ret_code=0
 else
-  printf "\n\t%s\n\n" "ERROR -- $($ts) --  ${type} Level ${rman_level} of database {{ db_name }} had errors, please have a look at the logfile: ${logfile}"
+  printf "\n\t%s\n\n" "ERROR -- $($ts) --  ${type} Level ${rman_level} of instance ${ora_inst_name} had errors, please have a look at the logfile: ${logfile}"
   ret_code=123
 fi
 exit ${ret_code}

--- a/roles/db-backups/templates/rman_full_backup.sh.j2
+++ b/roles/db-backups/templates/rman_full_backup.sh.j2
@@ -2,47 +2,51 @@
 #
 # Example: ./rman_full_backup.sh ORCL 0 2 2
 #
-         ORA_INST_NAME=${1}                             # Instance name-- should match /etc/oratab
-            RMAN_LEVEL=${2}                             # Backup level
-  RETENTION_REDUNDANCY=${3}                             # Retention
-       ARCH_REDUNDANCY=${4}                             # Archivelog redundancy
-                    TS="date +%Y-%m-%d_%H-%M-%S"        # A timestamp
-                A_DATE=$($TS)                           # The current date
-               LOG_DIR='{{ logs_dir }}'                 # A directory for the logs
-export NLS_DATE_FORMAT="DD/MM/YYYY HH24:MI:SS"          # A nice date format for RMAN logs
+ora_inst_name=${1}                       # Instance name-- should match /etc/oratab
+rman_level=${2}                          # Backup level
+retention_redundancy=${3}                # Retention
+arch_redundancy=${4}                     # Archivelog redundancy
+ts="date +%Y-%m-%d_%H-%M-%S"             # Timestamp format
+start_ts="$($ts)"                        # Start timestamp
+log_dir="{{ logs_dir }}"                 # A directory for the logs
+export NLS_DATE_FORMAT="YYYY-MM-DD HH24:MI:SS"
+#
+if [[ $# -ne 4 ]]; then
+  echo "Usage: $0 ora_inst_name rman_level retention_redundancy arch_redundancy" >&1
+  exit 1
+fi
 #
 # A tag for the logfile and output file depending on the backup level
 #
-if [[ "${RMAN_LEVEL}" = "0" ]]; then
-  TYPE="FULL"                                     # Full backup
+if [[ "${rman_level}" = "0" ]]; then
+  type="FULL"                            # Full backup
 else
-  TYPE="INCR"                                     # Incremental
+  type="INCR"                            # Incremental
 fi
 #
-# Check if $LOG_DIR exists; if not, we create it
+# Check if $log_dir exists; if not, we create it
 #
-if [[ ! -d "${LOG_DIR}" ]]; then
-  mkdir -p "${LOG_DIR}"
-  if [ $? -eq 0 ];  then
-    printf "\n\t%s\n\n" "INFO -- $($TS) -- ${LOG_DIR} successfully created."
+if [[ ! -d "${log_dir}" ]]; then
+  if mkdir -p "${log_dir}"; then
+    printf "\n\t%s\n\n" "INFO -- $($ts) -- ${log_dir} successfully created."
   else
-    printf "\n\t%s\n\n" "ERROR -- $($TS) -- Impossible to create ${LOG_DIR}; we wont be able to log this backup."
+    printf "\n\t%s\n\n" "ERROR -- $($ts) -- Impossible to create ${log_dir}; we wont be able to log this backup."
   fi
 fi
 #
 # We can now build the output file and logfile names
 #
-outfile="${LOG_DIR}/rman_${A_DATE}_${TYPE}_Level_${RMAN_LEVEL}.out"
-logfile="${LOG_DIR}/rman_${A_DATE}_${TYPE}_Level_${RMAN_LEVEL}.log"
+outfile="${log_dir}/rman_${start_ts}_${type}.out"
+logfile="${log_dir}/rman_${start_ts}_${type}.log"
 #
 # Set the oracle env
 #
-export ORACLE_SID=${ORA_INST_NAME}
-. oraenv <<< ${ORA_INST_NAME} > /dev/null 2>&1
+export ORACLE_SID="${ora_inst_name}"
+source oraenv <<< "${ora_inst_name}" > /dev/null 2>&1
 #
 # RMAN backup
 #
-${ORACLE_HOME}/bin/rman >> ${outfile} << EOF
+if "${ORACLE_HOME}/bin/rman" >> "${outfile}" << EOF
   set echo on
   spool log to '${logfile}'
   connect target {% if oracle_ver == "11.2.0.4.0" %}'/'{% else %}'/ AS SYSBACKUP'{% endif %}
@@ -51,24 +55,24 @@ ${ORACLE_HOME}/bin/rman >> ${outfile} << EOF
   configure device type disk parallelism 4;
 
   {% if backup_dest[0:1]  == "/" %}
-  configure controlfile autobackup format for device type disk to '{{ backup_dest }}/${ORA_INST_NAME}_%F';
-  configure channel device type disk format '{{ backup_dest }}/${ORA_INST_NAME}_${TYPE}_Level_${RMAN_LEVEL}_%U';
+  configure controlfile autobackup format for device type disk to '{{ backup_dest }}/${ora_inst_name}_%F';
+  configure channel device type disk format '{{ backup_dest }}/${ora_inst_name}_${type}_Level_${rman_level}_%U';
   {% else %}
   configure controlfile autobackup format for device type disk to '{{ backup_dest }}';
   configure channel device type disk format '{{ backup_dest }}';
   {% endif %}
   configure snapshot controlfile name to '+{{ reco_diskgroup }}/{{ db_name }}/snapcf_{{ db_name }}.f';
 
-  configure archivelog deletion policy to backed up ${ARCH_REDUNDANCY} times to disk;
-  configure retention policy to redundancy ${RETENTION_REDUNDANCY};
+  configure archivelog deletion policy to backed up ${arch_redundancy} times to disk;
+  configure retention policy to redundancy ${retention_redundancy};
   show all;
   run {
     backup check logical
-    incremental level=${RMAN_LEVEL} cumulative database
+    incremental level=${rman_level} cumulative database
     section size 32G
     filesperset 1
     include current controlfile
-    plus archivelog not backed up ${ARCH_REDUNDANCY} times;
+    plus archivelog not backed up ${arch_redundancy} times;
     report unrecoverable;
     report need backup;
   }
@@ -80,15 +84,15 @@ EOF
 #
 # Success or error output with the name of the logfile
 #
-if [ $? = 0 ]; then
-  printf "\n\t%s\n" "INFO -- $($TS) -- ${TYPE} Level ${RMAN_LEVEL} of database {{ db_name }} has been completed successfully."
-  printf "\t%s\n\n" "INFO -- $($TS) -- logfile used by this session: ${logfile}."
-  RET_CODE=0
+then
+  printf "\n\t%s\n" "INFO -- $($ts) -- ${type} Level ${rman_level} of database {{ db_name }} has been completed successfully."
+  printf "\t%s\n\n" "INFO -- $($ts) -- logfile used by this session: ${logfile}"
+  ret_code=0
 else
-  printf "\n\t%s\n\n" "ERROR -- $($TS) --  ${TYPE} Level ${RMAN_LEVEL} of database {{ db_name }} had errors, please have a look at the logfile: ${logfile}."
-  RET_CODE=123
+  printf "\n\t%s\n\n" "ERROR -- $($ts) --  ${type} Level ${rman_level} of database {{ db_name }} had errors, please have a look at the logfile: ${logfile}"
+  ret_code=123
 fi
-exit ${RET_CODE}
+exit ${ret_code}
 #
 #****************************************************************************************#
 #                       E N D      O F       S O U R C E                                *#


### PR DESCRIPTION
Update the RMAN backup and arch scripts in line with https://google.github.io/styleguide/shellguide.html as well as the shellcheck linter.  And, in order to simplify testing, move all the Jinja code to the top where substitutions are easier.

Key updates:
- Variables in lower case
- Consistent left-side formatting
- Removing $? checks: https://github.com/koalaman/shellcheck/wiki/SC2181
- Adding quoting when referencing variables
- Clarifying that a_date is really the start timestamp
- Jinja code limited to constant definitions
- Removing db_name references where the instance_name can be used instead
