### PR TITLE
Check for jmespath module

### DIFF
--- a/check-instance.yml
+++ b/check-instance.yml
@@ -21,6 +21,15 @@
         that: "ansible_version.full is version_compare('2.8', '>=')"
         fail_msg: "You must update Ansible to at least 2.8 to use these playbooks"
         success_msg: "Ansible version is {{ ansible_version.full }}, continuing"
+    - name: Confirm JSON parsing works
+      assert:
+        that: "{{ '{}' | json_query('[0]') == None }}"
+      register: test_json
+      ignore_errors: true
+    - name: Check for JSON parse failure
+      fail:
+        msg: "Python jmespath is missing; please install the python2-jmespath package on control node."
+      when: test_json.failed
   vars:
     allow_install_on_vm: false
 


### PR DESCRIPTION
Ansible's json_query requires the jsonpath module.  Although the ansible 
package installs it as a dependency in most OSes, a user may install 
ansible manually and encounter strange errors much later.  Adding a 
prereq check to run running json_query and to produce a cleaner error 
message if it can't run.

Testcase:

$ sudo rpm -e --nodeps python2-jmespath
$ ansible-playbook -i localhost, check-instance.yml
...
TASK [Confirm JSON parsing works] 
*****************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"msg": "You need to install \"jmespath\" 
prior to running json_query filter"}
...ignoring

TASK [Check for JSON parse failure] 
***************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Python 
jmespath is missing; please install the python2-jmespath package on 
control node."}

PLAY RECAP 
****************************************************************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    
failed=1    skipped=0    rescued=0    ignored=1

$ sudo yum install python2-jmespath
$ ansible-playbook -i localhost, check-instance.yml

PLAY [localhost] 
**********************************************************************************************************************************************************************

TASK [Verify that Ansible on control node meets the version 
requirements] 
*************************************************************************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "Ansible version is 2.9.23, continuing"
}

TASK [Confirm JSON parsing works] 
*****************************************************************************************************************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [Check for JSON parse failure] 
***************************************************************************************************************************************************
skipping: [localhost]