### PR TITLE
Simplify and speed up gcscopy

### DIFF
--- a/roles/swlib/tasks/gcscopy.yml
+++ b/roles/swlib/tasks/gcscopy.yml
@@ -17,35 +17,12 @@
   shell: |
     set -o pipefail
     {% for i in item.files %}
-    ssh -i {{ ansible_ssh_private_key_file }} {{ ansible_ssh_extra_args }} {{ ansible_ssh_user }}@{{ ansible_ssh_host }} \
-      "ls {{ swlib_path }}/{{ i }}"
-    if [[ $? -eq 0 ]]
+    if ! ssh -i {{ ansible_ssh_private_key_file }} {{ ansible_ssh_extra_args }} {{ ansible_ssh_user }}@{{ ansible_ssh_host }} \
+      "unzip -l {{ swlib_path }}/{{ i }}"
       then
-        ssh -i {{ ansible_ssh_private_key_file }} {{ ansible_ssh_extra_args }} {{ ansible_ssh_user }}@{{ ansible_ssh_host }} \
-          "unzip -t {{ swlib_path }}/{{ i }}"
-        if [[ $? -ne 0 ]]
-          then
-            gsutil cat gs://{{ swlib_mount_src }}/{{ i }} | ssh -i {{ ansible_ssh_private_key_file }} {{ ansible_ssh_extra_args }} \
-              {{ ansible_ssh_user }}@{{ ansible_ssh_host }} "cat > {{ swlib_path }}/{{ i }}"
-        fi
-       else
-         gsutil cat gs://{{ swlib_mount_src }}/{{ i }} | ssh -i {{ ansible_ssh_private_key_file }} {{ ansible_ssh_extra_args }} \
-           {{ ansible_ssh_user }}@{{ ansible_ssh_host }} "cat > {{ swlib_path }}/{{ i }}"
+        gsutil cat gs://{{ swlib_mount_src }}/{{ i }} | ssh -i {{ ansible_ssh_private_key_file }} {{ ansible_ssh_extra_args }} \
+          {{ ansible_ssh_user }}@{{ ansible_ssh_host }} "cat > {{ swlib_path }}/{{ i }}"
     fi
-        {% endfor %}
-  args:
-    executable: /bin/bash
-  with_items:
-    - "{{ gi_software }}"
-    - "{{ gi_interim_patches }}"
-  when: item.version == oracle_ver and patching_type is not defined
-  delegate_to: 127.0.0.1
-
-- name: gcscopy | Verify GI software zipfile integrity
-  shell: |
-    set -o pipefail
-    {% for i in item.files %}
-    unzip -t {{ swlib_path }}/{{ i }} > /dev/null
         {% endfor %}
   register: shell_result
   args:
@@ -54,116 +31,55 @@
     - "{{ gi_software }}"
     - "{{ gi_interim_patches }}"
   when: item.version == oracle_ver and patching_type is not defined
-  failed_when: shell_result.stderr != ""
+  changed_when: "'Date    Time    Name' not in shell_result.stdout"
+  delegate_to: 127.0.0.1
 
-- name: gcscopy | Copy GI patch software from GCS to target instance
+- name: gcscopy | Copy GI patches from GCS to target instance
   shell: |
     set -o pipefail
-    ssh -i {{ ansible_ssh_private_key_file }} {{ ansible_ssh_extra_args }} {{ ansible_ssh_user }}@{{ ansible_ssh_host }} \
-      "ls {{ swlib_path }}/{{ item.patchfile }}"
-    if [[ $? -eq 0 ]]
+    if ! ssh -i {{ ansible_ssh_private_key_file }} {{ ansible_ssh_extra_args }} {{ ansible_ssh_user }}@{{ ansible_ssh_host }} \
+      "unzip -l {{ swlib_path }}/{{ item.patchfile }}"
       then
-        ssh -i {{ ansible_ssh_private_key_file }} {{ ansible_ssh_extra_args }} {{ ansible_ssh_user }}@{{ ansible_ssh_host }} \
-          "unzip -t {{ swlib_path }}/{{ item.patchfile }}"
-        if [[ $? -ne 0 ]]
-          then
-            gsutil cat gs://{{ swlib_mount_src }}/{{ item.patchfile }} | ssh -i {{ ansible_ssh_private_key_file }} {{ ansible_ssh_extra_args }} \
-              {{ ansible_ssh_user }}@{{ ansible_ssh_host }} "cat > {{ swlib_path }}/{{ item.patchfile }}"
-        fi
-      else
         gsutil cat gs://{{ swlib_mount_src }}/{{ item.patchfile }} | ssh -i {{ ansible_ssh_private_key_file }} {{ ansible_ssh_extra_args }} \
           {{ ansible_ssh_user }}@{{ ansible_ssh_host }} "cat > {{ swlib_path }}/{{ item.patchfile }}"
     fi
-  args:
-    executable: /bin/bash
-  with_items:
-    - "{{ gi_patches }}"
-  when: item.release == oracle_rel and patching_type == "gi_patching"
-  delegate_to: 127.0.0.1
-
-- name: gcscopy | Verify GI patch software zipfile integrity
-  shell: |
-    set -o pipefail
-    {% for i in item.patchfile %}
-    unzip -t {{ swlib_path }}/{{ i }} > /dev/null
-        {% endfor %}
   register: shell_result
   args:
     executable: /bin/bash
   with_items:
     - "{{ gi_patches }}"
   when: item.release == oracle_rel and patching_type == "gi_patching"
-  failed_when: shell_result.stderr != ""
+  changed_when: "'Date    Time    Name' not in shell_result.stdout"
+  delegate_to: 127.0.0.1
 
 - name: gcscopy | Copy GI OPatch update files from GCS to target instance
   shell: |
     set -o pipefail
-    ssh -i {{ ansible_ssh_private_key_file }} {{ ansible_ssh_extra_args }} {{ ansible_ssh_user }}@{{ ansible_ssh_host }} \
-      "ls {{ swlib_path }}/{{ item.patchfile }}"
-    if [[ $? -eq 0 ]]
+    if ! ssh -i {{ ansible_ssh_private_key_file }} {{ ansible_ssh_extra_args }} {{ ansible_ssh_user }}@{{ ansible_ssh_host }} \
+      "unzip -l {{ swlib_path }}/{{ item.patchfile }}"
       then
-        ssh -i {{ ansible_ssh_private_key_file }} {{ ansible_ssh_extra_args }} {{ ansible_ssh_user }}@{{ ansible_ssh_host }} \
-          "unzip -t {{ swlib_path }}/{{ item.patchfile }}"
-        if [[ $? -ne 0 ]]
-          then
-            gsutil cat gs://{{ swlib_mount_src }}/{{ item.patchfile }} | ssh -i {{ ansible_ssh_private_key_file }} {{ ansible_ssh_extra_args }} \
-              {{ ansible_ssh_user }}@{{ ansible_ssh_host }} "cat > {{ swlib_path }}/{{ item.patchfile }}"
-        fi
-      else
         gsutil cat gs://{{ swlib_mount_src }}/{{ item.patchfile }} | ssh -i {{ ansible_ssh_private_key_file }} {{ ansible_ssh_extra_args }} \
           {{ ansible_ssh_user }}@{{ ansible_ssh_host }} "cat > {{ swlib_path }}/{{ item.patchfile }}"
     fi
-  args:
-    executable: /bin/bash
-  with_items:
-    - "{{ opatch_patches }}"
-  when: item.release == oracle_ver and patching_type is defined
-  delegate_to: 127.0.0.1
-
-- name: gcscopy | Verify GI OPatch update zipfile integrity
-  shell: |
-    set -o pipefail
-    unzip -t {{ swlib_path }}/{{ item.patchfile }} > /dev/null
   register: shell_result
   args:
     executable: /bin/bash
   with_items:
     - "{{ opatch_patches }}"
-  when: item.release == oracle_ver and patching_type is defined
-  failed_when: shell_result.stderr != ""
+  when: item.release == oracle_ver and oracle_rel != "base" and patching_type is defined
+  changed_when: "'Date    Time    Name' not in shell_result.stdout"
+  delegate_to: 127.0.0.1
 
 - name: gcscopy | Copy RDBMS software from GCS to target instance
   shell: |
     set -o pipefail
     {% for i in item.files %}
-    ssh -i {{ ansible_ssh_private_key_file }} {{ ansible_ssh_extra_args }} {{ ansible_ssh_user }}@{{ ansible_ssh_host }} \
-      "ls {{ swlib_path }}/{{ i }}"
-    if [[ $? -eq 0 ]]
+    if ! ssh -i {{ ansible_ssh_private_key_file }} {{ ansible_ssh_extra_args }} {{ ansible_ssh_user }}@{{ ansible_ssh_host }} \
+      "unzip -l {{ swlib_path }}/{{ i }}"
       then
-        ssh -i {{ ansible_ssh_private_key_file }} {{ ansible_ssh_extra_args }} {{ ansible_ssh_user }}@{{ ansible_ssh_host }} \
-          "unzip -t {{ swlib_path }}/{{ i }}"
-        if [[ $? -ne 0 ]]
-          then
-            gsutil cat gs://{{ swlib_mount_src }}/{{ i }} | ssh -i {{ ansible_ssh_private_key_file }} {{ ansible_ssh_extra_args }} \
-              {{ ansible_ssh_user }}@{{ ansible_ssh_host }} "cat > {{ swlib_path }}/{{ i }}"
-        fi
-       else
-         gsutil cat gs://{{ swlib_mount_src }}/{{ i }} | ssh -i {{ ansible_ssh_private_key_file }} {{ ansible_ssh_extra_args }} \
-           {{ ansible_ssh_user }}@{{ ansible_ssh_host }} "cat > {{ swlib_path }}/{{ i }}"
+        gsutil cat gs://{{ swlib_mount_src }}/{{ i }} | ssh -i {{ ansible_ssh_private_key_file }} {{ ansible_ssh_extra_args }} \
+          {{ ansible_ssh_user }}@{{ ansible_ssh_host }} "cat > {{ swlib_path }}/{{ i }}"
     fi
-        {% endfor %}
-  args:
-    executable: /bin/bash
-  with_items:
-    - "{{ rdbms_software }}"
-  when: item.version == oracle_ver and patching_type is not defined
-  delegate_to: 127.0.0.1
-
-- name: gcscopy | Verify RDBMS software zipfile integrity
-  shell: |
-    set -o pipefail
-    {% for i in item.files %}
-    unzip -t {{ swlib_path }}/{{ i }} > /dev/null
         {% endfor %}
   register: shell_result
   args:
@@ -171,43 +87,23 @@
   with_items:
     - "{{ rdbms_software }}"
   when: item.version == oracle_ver and patching_type is not defined
-  failed_when: shell_result.stderr != ""
+  changed_when: "'Date    Time    Name' not in shell_result.stdout"
+  delegate_to: 127.0.0.1
 
-- name: gcscopy | Copy RDBMS OPatch update files from GCS to target instance
+- name: gcscopy | Copy RDBMS patches from GCS to target instance
   shell: |
     set -o pipefail
-    ssh -i {{ ansible_ssh_private_key_file }} {{ ansible_ssh_extra_args }} {{ ansible_ssh_user }}@{{ ansible_ssh_host }} \
-      "ls {{ swlib_path }}/{{ item.patchfile }}"
-    if [[ $? -eq 0 ]]
+    if ! ssh -i {{ ansible_ssh_private_key_file }} {{ ansible_ssh_extra_args }} {{ ansible_ssh_user }}@{{ ansible_ssh_host }} \
+      "unzip -l {{ swlib_path }}/{{ item.patchfile }}"
       then
-        ssh -i {{ ansible_ssh_private_key_file }} {{ ansible_ssh_extra_args }} {{ ansible_ssh_user }}@{{ ansible_ssh_host }} \
-          "unzip -t {{ swlib_path }}/{{ item.patchfile }}"
-        if [[ $? -ne 0 ]]
-          then
-            gsutil cat gs://{{ swlib_mount_src }}/{{ item.patchfile }} | ssh -i {{ ansible_ssh_private_key_file }} {{ ansible_ssh_extra_args }} \
-              {{ ansible_ssh_user }}@{{ ansible_ssh_host }} "cat > {{ swlib_path }}/{{ item.patchfile }}"
-        fi
-      else
         gsutil cat gs://{{ swlib_mount_src }}/{{ item.patchfile }} | ssh -i {{ ansible_ssh_private_key_file }} {{ ansible_ssh_extra_args }} \
           {{ ansible_ssh_user }}@{{ ansible_ssh_host }} "cat > {{ swlib_path }}/{{ item.patchfile }}"
     fi
-  args:
-    executable: /bin/bash
-  with_items:
-    - "{{ rdbms_patches }}"
-  when: item.release == oracle_rel and patching_type == "db_patching"
-  delegate_to: 127.0.0.1
-
-- name: gcscopy | Verify RDBMS OPatch update zipfile integrity
-  shell: |
-    set -o pipefail
-    {% for i in item.patchfile %}
-    unzip -t {{ swlib_path }}/{{ i }} > /dev/null
-        {% endfor %}
   register: shell_result
   args:
     executable: /bin/bash
   with_items:
     - "{{ rdbms_patches }}"
   when: item.release == oracle_rel and patching_type == "db_patching"
-  failed_when: shell_result.stderr != ""
+  changed_when: "'Date    Time    Name' not in shell_result.stdout"
+  delegate_to: 127.0.0.1


### PR DESCRIPTION
The gcscopy.yml tasks use the gsutil cat command on the control node,
and stream it to the BMS host's software library.  This mulit-stage
process avoids a dependency on Internet access or gcloud authentication
on the BMS host iteslf, and instead uses the pre-configuraed state of a
cloud VM on the control node.  Additionally, gcscopy caches patch fiels
on the BMS host to avoid expensive re-downloads when not necessary.

To protect against gsutil cp failures and partially-written files,
"unzip -t" is used before and after to validate the archive.  This is a
slow and expensive process requiring reading multiple gigabytes of data.

In thie change, we replace the "unzip -t" with an "unzip -l", listing
the archive contents.  As zip directories are at the end of the file, it
provides good detection of partially-copied files with much reduced
overhead.

At the same time, we simplify the code by removing the ls step (which is
covered by the unzip), add changed_when logic that provides user
feedback when a re-download was required, and avoid the post-download
check, as we already get good coverage by ansible's implicit check or
return codes combined with the set -o pipefail inthe shell, which
captures errors in either the gsutil or cat commands; we do this by
looiing for the lack of unzip -l's headers, which would have indicated
an existing file was validated.

Unnecessary [[ $? -eq 0 ]] is removed from shell output, as per
https://github.com/koalaman/shellcheck/wiki/SC2181 recommendations.

Sample output:
https://gist.github.com/mfielding/9e6e33d051764e314017006e1fd20557