### PR TITLE
logging cmd line options passed

### DIFF
--- a/apply-patch.sh
+++ b/apply-patch.sh
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+echo Command used:
+echo "$0 $@"
+echo
 
 # Check if we're using the Mac stock getopt and fail if true
 out=`getopt -T`

--- a/cleanup-oracle.sh
+++ b/cleanup-oracle.sh
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+echo Command used:
+echo "$0 $@"
+echo
 
 GETOPT_MANDATORY="ora-version:,inventory-file:,yes-i-am-sure"
 GETOPT_OPTIONAL="ora-role-separation:,ora-disk-mgmt:,ora-swlib-path:,ora-staging:,ora-asm-disks:,ora-data-mounts:,help"

--- a/install-oracle.sh
+++ b/install-oracle.sh
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+echo Command used:
+echo "$0 $@"
+echo
+
 #
 #export ANSIBLE_LOG_PATH=~/ansible.log
 #export ANSIBLE_DEBUG=True"


### PR DESCRIPTION
During a given project or an install, there may be typically multiple installs, say, 20 or so.
When it's time to write up what was changed in each iteration, the log files are the places to look, but it takes a bit of redirection to make sense that this given log file was generated for these given options in a roundabout way.

To improve the context of the log file and to easily re-use the cmd-line options, it helps to log the bash arguments at the top of the log file.

With this commit, the output logfile shows up as:
```bash
[jcnarasimhan@control-node ~]$ head -20 ~/050521-mntrl-instlln/bms-toolkit/logs/test_logging
Command used:
./apply-patch.sh --ora-swlib-bucket gs://bmaas-testing-oracle-software --ora-swlib-path /u01/oracle_install --ora-staging /u01/oracle_install --ora-version 19.3.0.0.0 --inventory-file inventory_files/inventory_linuxserver44.orcl_orcl --ora-db-name orcl

Running with parameters from command line or environment variables:

ORA_DB_NAME=orcl
ORA_RELEASE=
ORA_STAGING=/u01/oracle_install
ORA_SWLIB_BUCKET=gs://bmaas-testing-oracle-software
ORA_SWLIB_PATH=/u01/oracle_install
ORA_VERSION=19.3.0.0.0

Ansible params: -i inventory_files/inventory_linuxserver44.orcl_orcl  
Found Ansible at /usr/bin/ansible-playbook
Running Ansible playbook: /usr/bin/ansible-playbook -i inventory_files/inventory_linuxserver44.orcl_orcl   patch.yml

PLAY [Set correct RDBMS release] ***********************************************************************************************************************************************

TASK [include_role : patch] *****
```