### PR TITLE
Default disk mount options to nofail

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Toolkit for installing and creating an initial Oracle database on Bare Metal Sol
             "name": "u01",
             "fstype":"xfs",
             "mount_point":"/u01",
-            "mount_opts":"defaults"
+            "mount_opts":"nofail"
         }
     ]
     ```

--- a/data_mounts_config.json
+++ b/data_mounts_config.json
@@ -5,7 +5,7 @@
 	"name": "u01",
 	"fstype":"xfs",
 	"mount_point":"/u01",
-	"mount_opts":"defaults"
+	"mount_opts":"nofail"
     },
     {
         "purpose": "diag",
@@ -13,6 +13,6 @@
 	"name": "u02",
 	"fstype":"xfs",
 	"mount_point":"/u02",
-	"mount_opts":"defaults"
+	"mount_opts":"nofail"
     }
 ]

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -913,7 +913,7 @@ file:
         "name": "u01",
         "fstype":"xfs",
         "mount_point":"/u01",
-        "mount_opts":"defaults"
+        "mount_opts":"nofail"
     },
     {
         "purpose": "diag",
@@ -921,7 +921,7 @@ file:
         "name": "u02",
         "fstype":"xfs",
         "mount_point":"/u02",
-        "mount_opts":"defaults"
+        "mount_opts":"nofail"
     }
 ]
 ```

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -24,8 +24,8 @@ swlib_path_default: "{{ oracle_user_data_mounts|selectattr('purpose', 'match', '
 
 # Installation related variables from dbasm
 oracle_user_data_mounts_default:
-  - { purpose: software, blk_device: /dev/BOGUS, fstype: xfs, mount_point: /u01, mount_opts: "defaults" }
-  - { purpose: diag, blk_device: /dev/BOGUS, fstype: xfs, mount_point: /u02, mount_opts: "defaults" }
+  - { purpose: software, blk_device: /dev/BOGUS, fstype: xfs, mount_point: /u01, mount_opts: "nofail" }
+  - { purpose: diag, blk_device: /dev/BOGUS, fstype: xfs, mount_point: /u02, mount_opts: "nofail" }
 data_mounts_definition_file: "{{ lookup('env','ORA_DATA_MOUNTS')|default('data_mounts_config.json',true) }}"
 data_mounts_input: "{{ lookup('file',data_mounts_definition_file,errors='ignore') }}"
 oracle_user_data_mounts: "{{ data_mounts_input | default(oracle_user_data_mounts_default,true) }}"

--- a/roles/host-storage/defaults/main.yml
+++ b/roles/host-storage/defaults/main.yml
@@ -14,5 +14,5 @@
 
 ---
 oracle_user_data_mounts:
-  - { purpose: software, blk_device: /dev/sdb, fstype: xfs, mount_point: /u01, mount_opts: default }
-  - { purpose: other, blk_device: /dev/sdc, fstype: xfs, mount_point: /u02 , mount_opts: default}
+  - { purpose: software, blk_device: /dev/sdb, fstype: xfs, mount_point: /u01, mount_opts: nofail }
+  - { purpose: other, blk_device: /dev/sdc, fstype: xfs, mount_point: /u02 , mount_opts: nofail }

--- a/roles/lsnr-create/tasks/main.yml
+++ b/roles/lsnr-create/tasks/main.yml
@@ -24,7 +24,7 @@
   failed_when:
     - "'firewall is not currently running' not in firewall_output.msg"
     - "'Permanent and Non-Permanent(immediate) operation' not in firewall_output.msg"
-  when: disable_firewall|bool is false
+  when: not disable_firewall|bool
   tags: lsnr-create
 
 - name: Test whether port is free


### PR DESCRIPTION
The toolit creates filesystem mounts specified in the
`--ora-data-mounts` parameter to `install-oracle.sh`, to store
contents like the ORACLE_HOME or diag dest.  A filesystem is
created here and added to /etc/fstab to mount on startup.  If
the filesystem is somehow not mountable, systemd prevents the
system from booting normally and enters emergency mode,
resulting in a hung system if no interactive console is
available.

This change adds a default "nofail" mount option, which
prevents the failure status from being propagated to systemd,
allowing the system to still boot normally, and the underlying
issue to be fixed.

Also fixing an issue with listener firewall to allow install to compelte.

Sample instal outputl: https://gist.github.com/mfielding/3867a17da4e01ff1cffea54f5c072a33