### PR TITLE
Disable avahi daemon as part of installation

### DIFF
--- a/roles/base-provision/tasks/main.yml
+++ b/roles/base-provision/tasks/main.yml
@@ -42,6 +42,18 @@
     state: absent
   tags: ntp
 
+- name: Disable avahi daemon
+  systemd:
+    name: "{{ item }}"
+    enabled: false
+    state: stopped
+  when:
+    cluster_name is defined
+  with_items:
+    - avahi-daemon.socket
+    - avahi-daemon.service
+  tags: cvu
+
 - name: Install required base OS packages
   package:
     name: "{{ packages }}"


### PR DESCRIPTION
The avahi daemon provides zero-configuration network services, 
leveraging multicast over the network.  There are known issues with 
Oracle RAC (MOS note 1501093.1, 1571485.1, 
https://access.redhat.com/solutions/25463). Here we explicitly stop it 
and disable startup on reboot.

https://gist.github.com/mfielding/26592ede08cd2dd6b08fb30cbb885b28