### PR TITLE
host provision config tasks that follow initial connection setup

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -136,3 +136,5 @@ disable_firewall: false
 instance_ssh_user: "{{ lookup('env','INSTANCE_SSH_USER')|lower|default('ansible',true) }}"
 firsttime_connect_user: "customeradmin"
 control_node_key_file: "~/.ssh/id_rsa_bms_toolkit"
+proxy_setup: "{{ lookup('env','ORA_PROXY_SETUP')|lower|default('false',true) }}"
+u01_lun: "{{ lookup('env','ORA_U01_LUN')|lower|default('',true) }}"

--- a/host-provision.sh
+++ b/host-provision.sh
@@ -28,7 +28,7 @@ if [ $? != 4 ]; then
 fi
 
 GETOPT_MANDATORY="instance-ip-addr:"
-GETOPT_OPTIONAL="instance-ssh-user:,help"
+GETOPT_OPTIONAL="instance-ssh-user:,proxy-setup:,u01-lun:,help"
 GETOPT_LONG="${GETOPT_MANDATORY},${GETOPT_OPTIONAL}"
 GETOPT_SHORT="h"
 
@@ -47,6 +47,14 @@ eval set -- "$options"
 
 while true; do
     case "$1" in
+    --u01-lun)
+        ORA_U01_LUN="$2"
+        shift;
+        ;;
+    --proxy-setup)
+        ORA_PROXY_SETUP="$2"
+        shift;
+        ;;
     --instance-ssh-user)
         INSTANCE_SSH_USER="$2"
         shift;
@@ -72,6 +80,8 @@ done
 
 export INSTANCE_SSH_USER
 export ORA_CS_HOSTS
+export ORA_PROXY_SETUP
+export ORA_U01_LUN
 export INVENTORY_FILE="$ORA_CS_HOSTS,"
 
 echo -e "Running with parameters from command line or environment variables:\n"

--- a/host-provision.yml
+++ b/host-provision.yml
@@ -26,73 +26,73 @@
 # Inventory file may be updated with: ansible_ssh_private_key_file and ansible_ssh_user=ansible
 # Prior to calling the next steps (i.e.: install-oracle.sh)
 
-- name: Create private public key pair locally
-  hosts: localhost
-  tasks:
-  - include_role:
-      name: host-provision
-      tasks_from: ssh-keygen.yml
-  tags: host-provision
+# - name: Create private public key pair locally
+#   hosts: localhost
+#   tasks:
+#   - include_role:
+#       name: host-provision
+#       tasks_from: ssh-keygen.yml
+#   tags: host-provision
 
-- name: Create user and transfer public key to set up ssh equivalence
-  hosts: all
-  vars_prompt:
-    - name: ansible_password
-      prompt: Enter customeradmin password
-  vars:
-    #ansible_ssh_extra_args can be input as a command line or the following reasonable default may be used:    
-    ansible_ssh_extra_args: '-o IdentityAgent=no'
-  become: yes
-  pre_tasks:
-    - name: Verify that Ansible on control node meets the version requirements
-      assert:
-        that: "ansible_version.full is version_compare('2.8', '>=')"
-        fail_msg: "You must update Ansible to at least 2.8 to use these playbooks"
-        success_msg: "Ansible version is {{ ansible_version.full }}, continuing"
-  tasks:
-  - include_role:
-      name: host-provision
-      tasks_from: user-setup.yml
-  remote_user: "{{ firsttime_connect_user }}"
-  tags: host-provision
+# - name: Create user and transfer public key to set up ssh equivalence
+#   hosts: all
+#   vars_prompt:
+#     - name: ansible_password
+#       prompt: Enter customeradmin password
+#   vars:
+#     #ansible_ssh_extra_args can be input as a command line or the following reasonable default may be used:    
+#     ansible_ssh_extra_args: '-o IdentityAgent=no'
+#   become: yes
+#   pre_tasks:
+#     - name: Verify that Ansible on control node meets the version requirements
+#       assert:
+#         that: "ansible_version.full is version_compare('2.8', '>=')"
+#         fail_msg: "You must update Ansible to at least 2.8 to use these playbooks"
+#         success_msg: "Ansible version is {{ ansible_version.full }}, continuing"
+#   tasks:
+#   - include_role:
+#       name: host-provision
+#       tasks_from: user-setup.yml
+#   remote_user: "{{ firsttime_connect_user }}"
+#   tags: host-provision
 
-- name: Perform config tasks (SSH equivalence validation, LVM setup, etc)
-  hosts: all
-  vars:
-    ansible_ssh_private_key_file: "{{ control_node_key_file }}"
-    #ansible_ssh_extra_args can be input as a command line or the following reasonable default may be used:    
-    ansible_ssh_extra_args: '-o IdentityAgent=no'
-  become: yes
-  tasks:
-  - include_role:
-      name: host-provision
-      tasks_from: config-tasks.yml
-  remote_user: "{{ instance_ssh_user }}"
-  tags: host-provision
+# - name: Perform config tasks (SSH equivalence validation, LVM setup, etc)
+#   hosts: all
+#   vars:
+#     ansible_ssh_private_key_file: "{{ control_node_key_file }}"
+#     #ansible_ssh_extra_args can be input as a command line or the following reasonable default may be used:    
+#     ansible_ssh_extra_args: '-o IdentityAgent=no -o ProxyCommand="ssh -W %h:%p -q jcnarasimhan@control-node.mfild.com"'
+#   become: yes
+#   tasks:
+#   - include_role:
+#       name: host-provision
+#       tasks_from: config-tasks.yml
+#   remote_user: "{{ instance_ssh_user }}"
+#   tags: host-provision
 
-# Not clubbing this play inside the main play that performs all config tasks
-# Reason: need to first connect as a non-sudo user (become: no) to get to the fact ansible_env['SSH_CLIENT']
-- name: Proxy setup [optional]
-  hosts: all
-  vars:
-    ansible_ssh_private_key_file: "{{ control_node_key_file }}"
-    #ansible_ssh_extra_args can be input as a command line or the following reasonable default may be used:    
-    ansible_ssh_extra_args: '-o IdentityAgent=no'
-  become: no
-  tasks:
-  - include_role:
-      name: host-provision
-      tasks_from: proxy.yml
-    when: proxy_setup|bool
-  remote_user: "{{ instance_ssh_user }}"
-  tags: host-provision
+# # Not clubbing this play inside the main play that performs all config tasks
+# # Reason: need to first connect as a non-sudo user (become: no) to get to the fact ansible_env['SSH_CLIENT']
+# - name: Proxy setup [optional]
+#   hosts: all
+#   vars:
+#     ansible_ssh_private_key_file: "{{ control_node_key_file }}"
+#     #ansible_ssh_extra_args can be input as a command line or the following reasonable default may be used:    
+#     ansible_ssh_extra_args: '-o IdentityAgent=no -o ProxyCommand="ssh -W %h:%p -q jcnarasimhan@control-node.mfild.com"'
+#   become: no
+#   tasks:
+#   - include_role:
+#       name: host-provision
+#       tasks_from: proxy.yml
+#     when: proxy_setup|bool
+#   remote_user: "{{ instance_ssh_user }}"
+#   tags: host-provision
 
 - name: Perform RHEL-specific config tasks (subscription-manager, etc)
   hosts: all
   vars:
     ansible_ssh_private_key_file: "{{ control_node_key_file }}"
     #ansible_ssh_extra_args can be input as a command line or the following reasonable default may be used:    
-    ansible_ssh_extra_args: '-o IdentityAgent=no'
+    ansible_ssh_extra_args: '-o IdentityAgent=no -o ProxyCommand="ssh -W %h:%p -q jcnarasimhan@control-node.mfild.com"'
   become: yes
   tasks:
   - include_role:

--- a/host-provision.yml
+++ b/host-provision.yml
@@ -26,35 +26,35 @@
 # Inventory file may be updated with: ansible_ssh_private_key_file and ansible_ssh_user=ansible
 # Prior to calling the next steps (i.e.: install-oracle.sh)
 
-# - name: Create private public key pair locally
-#   hosts: localhost
-#   tasks:
-#   - include_role:
-#       name: host-provision
-#       tasks_from: ssh-keygen.yml
-#   tags: host-provision
+- name: Create private public key pair locally
+  hosts: localhost
+  tasks:
+  - include_role:
+      name: host-provision
+      tasks_from: ssh-keygen.yml
+  tags: host-provision
 
-# - name: Create user and transfer public key to set up ssh equivalence
-#   hosts: all
-#   vars_prompt:
-#     - name: ansible_password
-#       prompt: Enter customeradmin password
-#   vars:
-#     #ansible_ssh_extra_args can be input as a command line or the following reasonable default may be used:    
-#     ansible_ssh_extra_args: '-o IdentityAgent=no'
-#   become: yes
-#   pre_tasks:
-#     - name: Verify that Ansible on control node meets the version requirements
-#       assert:
-#         that: "ansible_version.full is version_compare('2.8', '>=')"
-#         fail_msg: "You must update Ansible to at least 2.8 to use these playbooks"
-#         success_msg: "Ansible version is {{ ansible_version.full }}, continuing"
-#   tasks:
-#   - include_role:
-#       name: host-provision
-#       tasks_from: user-setup.yml
-#   remote_user: "{{ firsttime_connect_user }}"
-#   tags: host-provision
+- name: Create user and transfer public key to set up ssh equivalence
+  hosts: all
+  vars_prompt:
+    - name: ansible_password
+      prompt: Enter customeradmin password
+  vars:
+    #ansible_ssh_extra_args can be input as a command line or the following reasonable default may be used:    
+    ansible_ssh_extra_args: '-o IdentityAgent=no'
+  become: yes
+  pre_tasks:
+    - name: Verify that Ansible on control node meets the version requirements
+      assert:
+        that: "ansible_version.full is version_compare('2.8', '>=')"
+        fail_msg: "You must update Ansible to at least 2.8 to use these playbooks"
+        success_msg: "Ansible version is {{ ansible_version.full }}, continuing"
+  tasks:
+  - include_role:
+      name: host-provision
+      tasks_from: user-setup.yml
+  remote_user: "{{ firsttime_connect_user }}"
+  tags: host-provision
 
 - name: Perform config tasks (SSH equivalence validation, LVM setup, etc)
   hosts: all
@@ -67,7 +67,7 @@
   vars:
     ansible_ssh_private_key_file: "{{ control_node_key_file }}"
     #ansible_ssh_extra_args can be input as a command line or the following reasonable default may be used:    
-    ansible_ssh_extra_args: '-o IdentityAgent=no -o ProxyCommand="ssh -W %h:%p -q jcnarasimhan@control-node.mfild.com"'
+    ansible_ssh_extra_args: '-o IdentityAgent=no'
   become: yes
   tasks:
   - include_role:
@@ -83,7 +83,7 @@
   vars:
     ansible_ssh_private_key_file: "{{ control_node_key_file }}"
     #ansible_ssh_extra_args can be input as a command line or the following reasonable default may be used:    
-    ansible_ssh_extra_args: '-o IdentityAgent=no -o ProxyCommand="ssh -W %h:%p -q jcnarasimhan@control-node.mfild.com"'
+    ansible_ssh_extra_args: '-o IdentityAgent=no'
   become: no
   tasks:
   - include_role:

--- a/host-provision.yml
+++ b/host-provision.yml
@@ -26,73 +26,73 @@
 # Inventory file may be updated with: ansible_ssh_private_key_file and ansible_ssh_user=ansible
 # Prior to calling the next steps (i.e.: install-oracle.sh)
 
-# - name: Create private public key pair locally
-#   hosts: localhost
-#   tasks:
-#   - include_role:
-#       name: host-provision
-#       tasks_from: ssh-keygen.yml
-#   tags: host-provision
+- name: Create private public key pair locally
+  hosts: localhost
+  tasks:
+  - include_role:
+      name: host-provision
+      tasks_from: ssh-keygen.yml
+  tags: host-provision
 
-# - name: Create user and transfer public key to set up ssh equivalence
-#   hosts: all
-#   vars_prompt:
-#     - name: ansible_password
-#       prompt: Enter customeradmin password
-#   vars:
-#     #ansible_ssh_extra_args can be input as a command line or the following reasonable default may be used:    
-#     ansible_ssh_extra_args: '-o IdentityAgent=no'
-#   become: yes
-#   pre_tasks:
-#     - name: Verify that Ansible on control node meets the version requirements
-#       assert:
-#         that: "ansible_version.full is version_compare('2.8', '>=')"
-#         fail_msg: "You must update Ansible to at least 2.8 to use these playbooks"
-#         success_msg: "Ansible version is {{ ansible_version.full }}, continuing"
-#   tasks:
-#   - include_role:
-#       name: host-provision
-#       tasks_from: user-setup.yml
-#   remote_user: "{{ firsttime_connect_user }}"
-#   tags: host-provision
+- name: Create user and transfer public key to set up ssh equivalence
+  hosts: all
+  vars_prompt:
+    - name: ansible_password
+      prompt: Enter customeradmin password
+  vars:
+    #ansible_ssh_extra_args can be input as a command line or the following reasonable default may be used:    
+    ansible_ssh_extra_args: '-o IdentityAgent=no'
+  become: yes
+  pre_tasks:
+    - name: Verify that Ansible on control node meets the version requirements
+      assert:
+        that: "ansible_version.full is version_compare('2.8', '>=')"
+        fail_msg: "You must update Ansible to at least 2.8 to use these playbooks"
+        success_msg: "Ansible version is {{ ansible_version.full }}, continuing"
+  tasks:
+  - include_role:
+      name: host-provision
+      tasks_from: user-setup.yml
+  remote_user: "{{ firsttime_connect_user }}"
+  tags: host-provision
 
-# - name: Perform config tasks (SSH equivalence validation, LVM setup, etc)
-#   hosts: all
-#   vars:
-#     ansible_ssh_private_key_file: "{{ control_node_key_file }}"
-#     #ansible_ssh_extra_args can be input as a command line or the following reasonable default may be used:    
-#     ansible_ssh_extra_args: '-o IdentityAgent=no -o ProxyCommand="ssh -W %h:%p -q jcnarasimhan@control-node.mfild.com"'
-#   become: yes
-#   tasks:
-#   - include_role:
-#       name: host-provision
-#       tasks_from: config-tasks.yml
-#   remote_user: "{{ instance_ssh_user }}"
-#   tags: host-provision
+- name: Perform config tasks (SSH equivalence validation, LVM setup, etc)
+  hosts: all
+  vars:
+    ansible_ssh_private_key_file: "{{ control_node_key_file }}"
+    #ansible_ssh_extra_args can be input as a command line or the following reasonable default may be used:    
+    ansible_ssh_extra_args: '-o IdentityAgent=no'
+  become: yes
+  tasks:
+  - include_role:
+      name: host-provision
+      tasks_from: config-tasks.yml
+  remote_user: "{{ instance_ssh_user }}"
+  tags: host-provision
 
-# # Not clubbing this play inside the main play that performs all config tasks
-# # Reason: need to first connect as a non-sudo user (become: no) to get to the fact ansible_env['SSH_CLIENT']
-# - name: Proxy setup [optional]
-#   hosts: all
-#   vars:
-#     ansible_ssh_private_key_file: "{{ control_node_key_file }}"
-#     #ansible_ssh_extra_args can be input as a command line or the following reasonable default may be used:    
-#     ansible_ssh_extra_args: '-o IdentityAgent=no -o ProxyCommand="ssh -W %h:%p -q jcnarasimhan@control-node.mfild.com"'
-#   become: no
-#   tasks:
-#   - include_role:
-#       name: host-provision
-#       tasks_from: proxy.yml
-#     when: proxy_setup|bool
-#   remote_user: "{{ instance_ssh_user }}"
-#   tags: host-provision
+# Not clubbing this play inside the main play that performs all config tasks
+# Reason: need to first connect as a non-sudo user (become: no) to get to the fact ansible_env['SSH_CLIENT']
+- name: Proxy setup [optional]
+  hosts: all
+  vars:
+    ansible_ssh_private_key_file: "{{ control_node_key_file }}"
+    #ansible_ssh_extra_args can be input as a command line or the following reasonable default may be used:    
+    ansible_ssh_extra_args: '-o IdentityAgent=no'
+  become: no
+  tasks:
+  - include_role:
+      name: host-provision
+      tasks_from: proxy.yml
+    when: proxy_setup|bool
+  remote_user: "{{ instance_ssh_user }}"
+  tags: host-provision
 
 - name: Perform RHEL-specific config tasks (subscription-manager, etc)
   hosts: all
   vars:
     ansible_ssh_private_key_file: "{{ control_node_key_file }}"
     #ansible_ssh_extra_args can be input as a command line or the following reasonable default may be used:    
-    ansible_ssh_extra_args: '-o IdentityAgent=no -o ProxyCommand="ssh -W %h:%p -q jcnarasimhan@control-node.mfild.com"'
+    ansible_ssh_extra_args: '-o IdentityAgent=no'
   become: yes
   tasks:
   - include_role:

--- a/host-provision.yml
+++ b/host-provision.yml
@@ -26,46 +26,69 @@
 # Inventory file may be updated with: ansible_ssh_private_key_file and ansible_ssh_user=ansible
 # Prior to calling the next steps (i.e.: install-oracle.sh)
 
-- name: Create private public key pair locally
-  hosts: localhost
-  tasks:
-  - include_role:
-      name: host-provision
-      tasks_from: ssh-keygen.yml
-  tags: host-provision
+# - name: Create private public key pair locally
+#   hosts: localhost
+#   tasks:
+#   - include_role:
+#       name: host-provision
+#       tasks_from: ssh-keygen.yml
+#   tags: host-provision
 
-- name: Create user and transfer public key to set up ssh equivalence
-  hosts: all
-  vars_prompt:
-    - name: ansible_password
-      prompt: Enter customeradmin password
-  vars:
-    #ansible_ssh_extra_args can be input as a command line or the following reasonable default may be used:    
-    ansible_ssh_extra_args: '-o IdentityAgent=no'
-  become: yes
-  pre_tasks:
-    - name: Verify that Ansible on control node meets the version requirements
-      assert:
-        that: "ansible_version.full is version_compare('2.8', '>=')"
-        fail_msg: "You must update Ansible to at least 2.8 to use these playbooks"
-        success_msg: "Ansible version is {{ ansible_version.full }}, continuing"
-  tasks:
-  - include_role:
-      name: host-provision
-      tasks_from: user-setup.yml
-  remote_user: "{{ firsttime_connect_user }}"
-  tags: host-provision
+# - name: Create user and transfer public key to set up ssh equivalence
+#   hosts: all
+#   vars_prompt:
+#     - name: ansible_password
+#       prompt: Enter customeradmin password
+#   vars:
+#     #ansible_ssh_extra_args can be input as a command line or the following reasonable default may be used:    
+#     ansible_ssh_extra_args: '-o IdentityAgent=no'
+#   become: yes
+#   pre_tasks:
+#     - name: Verify that Ansible on control node meets the version requirements
+#       assert:
+#         that: "ansible_version.full is version_compare('2.8', '>=')"
+#         fail_msg: "You must update Ansible to at least 2.8 to use these playbooks"
+#         success_msg: "Ansible version is {{ ansible_version.full }}, continuing"
+#   tasks:
+#   - include_role:
+#       name: host-provision
+#       tasks_from: user-setup.yml
+#   remote_user: "{{ firsttime_connect_user }}"
+#   tags: host-provision
 
 - name: Perform config tasks (SSH equivalence validation, LVM setup, etc)
   hosts: all
+  vars_prompt:
+    - name: rhel_username
+      prompt: Enter username for RHEL support
+      private: no
+    - name: rhel_password
+      prompt: Enter password for RHEL support
   vars:
     ansible_ssh_private_key_file: "{{ control_node_key_file }}"
     #ansible_ssh_extra_args can be input as a command line or the following reasonable default may be used:    
-    ansible_ssh_extra_args: '-o IdentityAgent=no'
+    ansible_ssh_extra_args: '-o IdentityAgent=no -o ProxyCommand="ssh -W %h:%p -q jcnarasimhan@control-node.mfild.com"'
   become: yes
   tasks:
   - include_role:
       name: host-provision
       tasks_from: config-tasks.yml
+  remote_user: "{{ instance_ssh_user }}"
+  tags: host-provision
+
+# Not clubbing  the following play inside the previous play that performs all config tasks
+# Reason: need to first connect as a non-sudo user (become: no) to get to the fact ansible_env['SSH_CLIENT']
+- name: Proxy setup and epel rpm installs [optional]
+  hosts: all
+  vars:
+    ansible_ssh_private_key_file: "{{ control_node_key_file }}"
+    #ansible_ssh_extra_args can be input as a command line or the following reasonable default may be used:    
+    ansible_ssh_extra_args: '-o IdentityAgent=no -o ProxyCommand="ssh -W %h:%p -q jcnarasimhan@control-node.mfild.com"'
+  become: no
+  tasks:
+  - include_role:
+      name: host-provision
+      tasks_from: proxy.yml
+    when: proxy_setup|bool
   remote_user: "{{ instance_ssh_user }}"
   tags: host-provision

--- a/host-provision.yml
+++ b/host-provision.yml
@@ -58,12 +58,6 @@
 
 - name: Perform config tasks (SSH equivalence validation, LVM setup, etc)
   hosts: all
-  vars_prompt:
-    - name: rhel_username
-      prompt: Enter username for RHEL support
-      private: no
-    - name: rhel_password
-      prompt: Enter password for RHEL support
   vars:
     ansible_ssh_private_key_file: "{{ control_node_key_file }}"
     #ansible_ssh_extra_args can be input as a command line or the following reasonable default may be used:    
@@ -76,9 +70,9 @@
   remote_user: "{{ instance_ssh_user }}"
   tags: host-provision
 
-# Not clubbing  the following play inside the previous play that performs all config tasks
+# Not clubbing this play inside the main play that performs all config tasks
 # Reason: need to first connect as a non-sudo user (become: no) to get to the fact ansible_env['SSH_CLIENT']
-- name: Proxy setup and epel rpm installs [optional]
+- name: Proxy setup [optional]
   hosts: all
   vars:
     ansible_ssh_private_key_file: "{{ control_node_key_file }}"
@@ -90,5 +84,21 @@
       name: host-provision
       tasks_from: proxy.yml
     when: proxy_setup|bool
+  remote_user: "{{ instance_ssh_user }}"
+  tags: host-provision
+
+- name: Perform RHEL-specific config tasks (subscription-manager, etc)
+  hosts: all
+  vars:
+    ansible_ssh_private_key_file: "{{ control_node_key_file }}"
+    #ansible_ssh_extra_args can be input as a command line or the following reasonable default may be used:    
+    ansible_ssh_extra_args: '-o IdentityAgent=no'
+  become: yes
+  tasks:
+  - include_role:
+      name: host-provision
+      tasks_from: rhel-config-tasks.yml
+    when:
+      - ansible_distribution == 'RedHat'
   remote_user: "{{ instance_ssh_user }}"
   tags: host-provision

--- a/roles/host-provision/tasks/config-tasks.yml
+++ b/roles/host-provision/tasks/config-tasks.yml
@@ -13,50 +13,28 @@
 # limitations under the License.
 
 
-- name: Validate ssh equivalence (passwordless connection) and sudo escalation for new user
+- name: config-tasks | Validate ssh equivalence (passwordless connection) and sudo escalation for new user
   ping:
   tags: host-provision
 
-
-# Not including ntp set up, as we already have code path built into `base-provision` role
-# that processes the commmand line switch: `--ntp-pref`
-
-
 # LVM creation
 # The net result will be that `/dev/mapper/db-sw` can be input into `install-oracle.sh` for local u01 storage
-- name: config-tasks | Create LVM layer
-  # vgcreate <VG> <block device WWID>
-  shell: vgcreate db {{ u01_lun }}
+- name: config-tasks | Create LVM layer - vgcreate
+  # added vgremove for idempotency of the script
+  # vgremove -y <VG>
+  # vgcreate -y <VG> <block device WWID>
+  shell: |
+    vgremove -y db 
+    vgcreate -y db {{ u01_lun }}
   when:
-    - u01_lun | length > 0    
+    - u01_lun | length > 0
+  ignore_errors: yes #to ignore when vgremove tries to remove non-existent vg the very first time this is run
   tags: host-provision
 
-- name: Create logical volume
+- name: config-tasks | Create LVM layer - lvcreate
   # lvcreate -l 100%FREE -n <LV> <VG>
   shell: lvcreate -l 100%FREE -n sw db
   when:
     - u01_lun | length > 0    
   tags: host-provision
 
-
-# RHEL specific: subscription manager
-- name: Remove registrations
-  become: true
-  redhat_subscription:
-    state: absent
-  when:
-    - ansible_distribution == 'RedHat'
-  tags: host-provision
-
-- name: Register host
-  become: true
-  redhat_subscription:
-    state: present
-    username: "{{ rhel_username }}"
-    password: "{{ rhel_password }}"
-    auto_attach: true
-  # we ignore when: "This system is already registered" is in the output
-  ignore_errors: yes
-  when:
-    - ansible_distribution == 'RedHat'
-  tags: host-provision

--- a/roles/host-provision/tasks/config-tasks.yml
+++ b/roles/host-provision/tasks/config-tasks.yml
@@ -17,10 +17,46 @@
   ping:
   tags: host-provision
 
-# Placeholder for the core config tasks to be executed by the host-provision.sh utility
-# - name: config-tasks | Create LVM layer
-# ...
+
+# Not including ntp set up, as we already have code path built into `base-provision` role
+# that processes the commmand line switch: `--ntp-pref`
 
 
-# - name: config-tasks | For RHEL, subscription manager
-# ...
+# LVM creation
+# The net result will be that `/dev/mapper/db-sw` can be input into `install-oracle.sh` for local u01 storage
+- name: config-tasks | Create LVM layer
+  # vgcreate <VG> <block device WWID>
+  shell: vgcreate db {{ u01_lun }}
+  when:
+    - u01_lun | length > 0    
+  tags: host-provision
+
+- name: Create logical volume
+  # lvcreate -l 100%FREE -n <LV> <VG>
+  shell: lvcreate -l 100%FREE -n sw db
+  when:
+    - u01_lun | length > 0    
+  tags: host-provision
+
+
+# RHEL specific: subscription manager
+- name: Remove registrations
+  become: true
+  redhat_subscription:
+    state: absent
+  when:
+    - ansible_distribution == 'RedHat'
+  tags: host-provision
+
+- name: Register host
+  become: true
+  redhat_subscription:
+    state: present
+    username: "{{ rhel_username }}"
+    password: "{{ rhel_password }}"
+    auto_attach: true
+  # we ignore when: "This system is already registered" is in the output
+  ignore_errors: yes
+  when:
+    - ansible_distribution == 'RedHat'
+  tags: host-provision

--- a/roles/host-provision/tasks/proxy.yml
+++ b/roles/host-provision/tasks/proxy.yml
@@ -12,15 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# The tasks in this file are dependent on the fact that the control-node
+# has a HTTP proxy server like Squid installed and can act as the gateway
+# For more background, please refer:
+# https://cloud.google.com/vpc/docs/special-configurations#proxyvm
 
-- name: proxy | Set fact
+- name: proxy | Get control node IP
   set_fact:
     proxy_ip: "{{ ansible_env['SSH_CLIENT'].split() | first }}"
   # debug:
   #   var: proxy_ip
   tags: host-provision
 
-- name: proxy | Validate proxy connectivity
+- name: proxy | Validate proxy connectivity via control node
   uri:
     url: https://www.google.com
     status_code: 200
@@ -28,7 +32,7 @@
     https_proxy: "http://{{ proxy_ip }}:3128"
   tags: host-provision
 
-- name: proxy | Add gateway instance to /etc/hosts
+- name: proxy | Add control node as gateway-instance to /etc/hosts
   become: true
   lineinfile:
     dest: /etc/hosts
@@ -37,7 +41,7 @@
     backup: yes    
   tags: host-provision
 
-- name: proxy | Add proxy to /etc/profile.d
+- name: proxy | Add client side proxy environment variables to /etc/profile.d
   become: true
   copy:
     dest: /etc/profile.d/proxy.sh
@@ -58,35 +62,3 @@
     backup: yes
   tags: host-provision
 
-- name: proxy | Add repo
-  become: true
-  yum_repository:
-    name: epel
-    description: EPEL YUM repo added by bms toolkit
-    mirrorlist: https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch
-    enabled: no
-  tags: host-provision
-
-- name: proxy | Add EPEL GPG key
-  become: true
-  rpm_key:
-    key: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
-    state: present
-  tags: host-provision
-
-- name: proxy | Install useful packages
-  become: true
-  yum:
-    name: "{{ packages }}"
-    enablerepo: "epel"
-  vars:
-    packages:
-    - strace
-    - tcpdump
-    - traceroute
-    - perf
-    - lsof
-    - mlocate
-    - iotop
-    - iftop
-  tags: host-provision

--- a/roles/host-provision/tasks/proxy.yml
+++ b/roles/host-provision/tasks/proxy.yml
@@ -1,0 +1,92 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+- name: proxy | Set fact
+  set_fact:
+    proxy_ip: "{{ ansible_env['SSH_CLIENT'].split() | first }}"
+  # debug:
+  #   var: proxy_ip
+  tags: host-provision
+
+- name: proxy | Validate proxy connectivity
+  uri:
+    url: https://www.google.com
+    status_code: 200
+  environment:
+    https_proxy: "http://{{ proxy_ip }}:3128"
+  tags: host-provision
+
+- name: proxy | Add gateway instance to /etc/hosts
+  become: true
+  lineinfile:
+    dest: /etc/hosts
+    regexp: '.*gateway-instance.*'
+    line: "{{ proxy_ip }} gateway-instance gateway-instance."
+    backup: yes    
+  tags: host-provision
+
+- name: proxy | Add proxy to /etc/profile.d
+  become: true
+  copy:
+    dest: /etc/profile.d/proxy.sh
+    content: |
+            export http_proxy="http://gateway-instance:3128"
+            export https_proxy="http://gateway-instance:3128"
+            export ftp_proxy="http://gateway-instance:3128"
+    backup: yes
+  tags: host-provision
+
+- name: proxy | Update proxy in sudoers
+  become: true
+  lineinfile:
+    dest: /etc/sudoers
+    regexp: ".*env_keep.*proxy.*"
+    line: 'Defaults env_keep += "ftp_proxy http_proxy https_proxy no_proxy"'
+    validate: 'visudo -cf %s'
+    backup: yes
+  tags: host-provision
+
+- name: proxy | Add repo
+  become: true
+  yum_repository:
+    name: epel
+    description: EPEL YUM repo added by bms toolkit
+    mirrorlist: https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch
+    enabled: no
+  tags: host-provision
+
+- name: proxy | Add EPEL GPG key
+  become: true
+  rpm_key:
+    key: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+    state: present
+  tags: host-provision
+
+- name: proxy | Install useful packages
+  become: true
+  yum:
+    name: "{{ packages }}"
+    enablerepo: "epel"
+  vars:
+    packages:
+    - strace
+    - tcpdump
+    - traceroute
+    - perf
+    - lsof
+    - mlocate
+    - iotop
+    - iftop
+  tags: host-provision

--- a/roles/host-provision/tasks/rhel-config-tasks.yml
+++ b/roles/host-provision/tasks/rhel-config-tasks.yml
@@ -12,33 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: rhel-config-tasks | Get control node IP
-  set_fact:
-    proxy_ip: "{{ ansible_env['SSH_CLIENT'].split() | first }}"
-  tags: host-provision
-
-- name: rhel-config-tasks | Validate proxy connectivity via control node
-  uri:
-    url: https://www.google.com
-    status_code: 200
-  environment:
-    https_proxy: "http://{{ proxy_ip }}:3128"
-
 # We check and evaluate subscription status 
 # Only if the system is not subscribed (Status: Unknown), then we prompt for RedHat credentials
 - name: rhel-config-tasks | Get current registration status
   become: true
   shell: |
-    /sbin/subscription-manager list |grep Status: |awk '{print $2}'
+    /sbin/subscription-manager list
   register: rhsm_status
   tags: host-provision
+
+- name: rhel-config-tasks | Print current RHSM status
+  debug:
+    var: rhsm_status.stdout
+  tags: host-provision    
 
 - name: rhel-config-tasks | Get RHEL username
   pause:
     prompt: Enter username for RHEL support
   register: rhel_username
   when:
-    - rhsm_status.stdout !='Subscribed'
+    - '"Status:         Subscribed" not in rhsm_status.stdout'
   tags: host-provision
 
 - name: rhel-config-tasks | Get RHEL password
@@ -47,7 +40,7 @@
     echo: no
   register: rhel_password
   when:
-    - rhsm_status.stdout !='Subscribed'  
+    - '"Status:         Subscribed" not in rhsm_status.stdout'
   tags: host-provision
 
 - name: rhel-config-tasks | Register host
@@ -56,7 +49,8 @@
     state: present
     username: "{{ rhel_username.user_input }}"
     password: "{{ rhel_password.user_input }}"
-    auto_attach: true
+    auto_attach: yes
+    force_register: yes
   when:
-    - rhsm_status.stdout !='Subscribed'  
+    - '"Status:         Subscribed" not in rhsm_status.stdout'
   tags: host-provision

--- a/roles/host-provision/tasks/rhel-config-tasks.yml
+++ b/roles/host-provision/tasks/rhel-config-tasks.yml
@@ -12,23 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: rhel-config-tasks | Validate internet connectivity via control node
+- name: rhel-config-tasks | Get control node IP
+  set_fact:
+    proxy_ip: "{{ ansible_env['SSH_CLIENT'].split() | first }}"
+  tags: host-provision
+
+- name: rhel-config-tasks | Validate proxy connectivity via control node
   uri:
     url: https://www.google.com
     status_code: 200
-  tags: host-provision
+  environment:
+    https_proxy: "http://{{ proxy_ip }}:3128"
 
+# We check and evaluate subscription status 
+# Only if the system is not subscribed (Status: Unknown), then we prompt for RedHat credentials
 - name: rhel-config-tasks | Get current registration status
   become: true
   shell: |
     /sbin/subscription-manager list |grep Status: |awk '{print $2}'
   register: rhsm_status
   tags: host-provision
-
-- name: rhel-config-tasks | Print current RHSM status
-  debug:
-    var: rhsm_status.stdout
-  tags: host-provision    
 
 - name: rhel-config-tasks | Get RHEL username
   pause:

--- a/roles/host-provision/tasks/rhel-config-tasks.yml
+++ b/roles/host-provision/tasks/rhel-config-tasks.yml
@@ -1,0 +1,59 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: config-tasks | Validate internet connectivity via control node
+  uri:
+    url: https://www.google.com
+    status_code: 200
+  tags: host-provision
+
+- name: config-tasks | Get current registration status
+  become: true
+  shell: |
+    /sbin/subscription-manager list |grep Status: |awk '{print $2}'
+  register: rhsm_status
+  tags: host-provision
+
+- name: config-tasks | Print current RHSM status
+  debug:
+    var: rhsm_status.stdout
+  tags: host-provision    
+
+- name: config-tasks | Get RHEL username
+  pause:
+    prompt: Enter username for RHEL support
+  register: rhel_username
+  when:
+    - rhsm_status.stdout !='Subscribed'
+  tags: host-provision
+
+- name: config-tasks | Get RHEL password
+  pause:
+    prompt: Enter password for RHEL support
+    echo: no
+  register: rhel_password
+  when:
+    - rhsm_status.stdout !='Subscribed'  
+  tags: host-provision
+
+- name: config-tasks | Register host
+  become: true
+  redhat_subscription:
+    state: present
+    username: "{{ rhel_username.user_input }}"
+    password: "{{ rhel_password.user_input }}"
+    auto_attach: true
+  when:
+    - rhsm_status.stdout !='Subscribed'  
+  tags: host-provision

--- a/roles/host-provision/tasks/rhel-config-tasks.yml
+++ b/roles/host-provision/tasks/rhel-config-tasks.yml
@@ -12,25 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: config-tasks | Validate internet connectivity via control node
+- name: rhel-config-tasks | Validate internet connectivity via control node
   uri:
     url: https://www.google.com
     status_code: 200
   tags: host-provision
 
-- name: config-tasks | Get current registration status
+- name: rhel-config-tasks | Get current registration status
   become: true
   shell: |
     /sbin/subscription-manager list |grep Status: |awk '{print $2}'
   register: rhsm_status
   tags: host-provision
 
-- name: config-tasks | Print current RHSM status
+- name: rhel-config-tasks | Print current RHSM status
   debug:
     var: rhsm_status.stdout
   tags: host-provision    
 
-- name: config-tasks | Get RHEL username
+- name: rhel-config-tasks | Get RHEL username
   pause:
     prompt: Enter username for RHEL support
   register: rhel_username
@@ -38,7 +38,7 @@
     - rhsm_status.stdout !='Subscribed'
   tags: host-provision
 
-- name: config-tasks | Get RHEL password
+- name: rhel-config-tasks | Get RHEL password
   pause:
     prompt: Enter password for RHEL support
     echo: no
@@ -47,7 +47,7 @@
     - rhsm_status.stdout !='Subscribed'  
   tags: host-provision
 
-- name: config-tasks | Register host
+- name: rhel-config-tasks | Register host
   become: true
   redhat_subscription:
     state: present

--- a/roles/host-provision/tasks/ssh-keygen.yml
+++ b/roles/host-provision/tasks/ssh-keygen.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Creates .ssh directory in control node if it does not exist
+- name: ssh-keygen | Creates .ssh directory in control node if it does not exist
   file:
     path: ~/.ssh
     state: directory


### PR DESCRIPTION
Post the user creation in the previous PR, extending the previously merged code with additional functionality in this PR.

Command called as:
```bash
✔ ~/DriveFS/My Drive/bmaas/host_provisioning/bms-toolkit [host-provision|…1] 
21:34 $ runlocalssh ./host-provision.sh --instance-ip-addr 172.16.30.1  --instance-ssh-user ansible9 --proxy-setup false --u01-lun /dev/mapper/3600a098038314344372b4f75392d3850 
Command used:
/usr/local/google/home/jcnarasimhan/DriveFS/My Drive/bmaas/host_provisioning/bms-toolkit/host-provision.sh --instance-ip-addr 172.16.30.1 --instance-ssh-user ansible9 --proxy-setup false --u01-lun /dev/mapper/3600a098038314344372b4f75392d3850

Running with parameters from command line or environment variables:

INSTANCE_SSH_USER=ansible9
INVENTORY_FILE=172.16.30.1,
ORA_CS_HOSTS=172.16.30.1
ORA_PROXY_SETUP=false
ORA_U01_LUN=/dev/mapper/3600a098038314344372b4f75392d3850

Found Ansible at /usr/bin/ansible-playbook

Running Ansible playbook: /usr/bin/ansible-playbook -i 172.16.30.1,   host-provision.yml

PLAY [Create private public key pair locally] **********************************************************************************************************************************

TASK [Gathering Facts] *********************************************************************************************************************************************************
ok: [localhost]

TASK [host-provision : Creates .ssh directory in control node if it does not exist] ********************************************************************************************
ok: [localhost]

```