### PR TITLE
Remove dependency on `which` in `cleanup-oracle.sh` and `install-oracle.sh`

### DIFF
--- a/apply-patch.sh
+++ b/apply-patch.sh
@@ -197,12 +197,12 @@ fi
 
 export ANSIBLE_NOCOWS=1
 
-ANSIBLE_PLAYBOOK=`which ansible-playbook 2> /dev/null`
-if [ $? -ne 0 ]; then
-    echo "Ansible executable not found in path"
-    exit 3
+ANSIBLE_PLAYBOOK="ansible-playbook"
+if ! type ansible-playbook > /dev/null 2>&1; then
+  echo "Ansible executable not found in path"
+  exit 3
 else
-    echo "Found Ansible at $ANSIBLE_PLAYBOOK"
+  echo "Found Ansible: `type ansible-playbook`"
 fi
 
 

--- a/check-swlib.sh
+++ b/check-swlib.sh
@@ -132,12 +132,12 @@ ANSIBLE_EXTRA_PARAMS="${*}"
 
 export ANSIBLE_DISPLAY_SKIPPED_HOSTS=false
 
-ANSIBLE_PLAYBOOK=`which ansible-playbook 2> /dev/null`
-if [ $? -ne 0 ]; then
+ANSIBLE_PLAYBOOK="ansible-playbook"
+if ! type ansible-playbook > /dev/null 2>&1; then
   echo "Ansible executable not found in path"
   exit 3
 else
-  echo "Found Ansible at $ANSIBLE_PLAYBOOK"
+  echo "Found Ansible: `type ansible-playbook`"
 fi
 
 # exit on any error from the following scripts

--- a/cleanup-oracle.sh
+++ b/cleanup-oracle.sh
@@ -193,10 +193,11 @@ fi
 export ANSIBLE_NOCOWS=1
 
 ANSIBLE_PLAYBOOK="ansible-playbook"
-ANSIBLE_PLAYBOOK_CHECK=`ansible-playbook --version 2> /dev/null`
-if [ $? -ne 0 ]; then
-    echo "Ansible executable not found in path"
-    exit 3
+if ! type ansible-playbook > /dev/null 2>&1; then
+  echo "Ansible executable not found in path"
+  exit 3
+else
+  echo "Found Ansible: `type ansible-playbook`"
 fi
 
 # exit on any error from the following scripts

--- a/cleanup-oracle.sh
+++ b/cleanup-oracle.sh
@@ -192,12 +192,11 @@ fi
 
 export ANSIBLE_NOCOWS=1
 
-ANSIBLE_PLAYBOOK=`which ansible-playbook 2> /dev/null`
+ANSIBLE_PLAYBOOK="ansible-playbook"
+ANSIBLE_PLAYBOOK_CHECK=`ansible-playbook --version 2> /dev/null`
 if [ $? -ne 0 ]; then
     echo "Ansible executable not found in path"
     exit 3
-else
-    echo "Found Ansible at $ANSIBLE_PLAYBOOK"
 fi
 
 # exit on any error from the following scripts

--- a/host-provision.sh
+++ b/host-provision.sh
@@ -93,12 +93,12 @@ ANSIBLE_EXTRA_PARAMS="${*}"
 
 export ANSIBLE_DISPLAY_SKIPPED_HOSTS=false
 
-ANSIBLE_PLAYBOOK=`which ansible-playbook 2> /dev/null`
-if [ $? -ne 0 ]; then
+ANSIBLE_PLAYBOOK="ansible-playbook"
+if ! type ansible-playbook > /dev/null 2>&1; then
   echo "Ansible executable not found in path"
   exit 3
 else
-  echo "Found Ansible at $ANSIBLE_PLAYBOOK"
+  echo "Found Ansible: `type ansible-playbook`"
 fi
 
 # exit on any error from the following scripts

--- a/install-oracle.sh
+++ b/install-oracle.sh
@@ -888,10 +888,11 @@ fi
 export ANSIBLE_NOCOWS=1
 
 ANSIBLE_PLAYBOOK="ansible-playbook"
-ANSIBLE_PLAYBOOK_CHECK=`ansible-playbook --version 2> /dev/null`
-if [ $? -ne 0 ]; then
-    echo "Ansible executable not found in path"
-    exit 3
+if ! type ansible-playbook > /dev/null 2>&1; then
+  echo "Ansible executable not found in path"
+  exit 3
+else
+  echo "Found Ansible: `type ansible-playbook`"
 fi
 
 # exit on any error from the following scripts

--- a/install-oracle.sh
+++ b/install-oracle.sh
@@ -887,12 +887,11 @@ fi
 
 export ANSIBLE_NOCOWS=1
 
-ANSIBLE_PLAYBOOK=`which ansible-playbook 2> /dev/null`
+ANSIBLE_PLAYBOOK="ansible-playbook"
+ANSIBLE_PLAYBOOK_CHECK=`ansible-playbook --version 2> /dev/null`
 if [ $? -ne 0 ]; then
-  echo "Ansible executable not found in path"
-  exit 3
-else
-  echo "Found Ansible at $ANSIBLE_PLAYBOOK"
+    echo "Ansible executable not found in path"
+    exit 3
 fi
 
 # exit on any error from the following scripts


### PR DESCRIPTION
As noted in (internal): https://buganizer.corp.google.com/issues/202240337#comment10, the `cleanup-oracle.sh` trips up at the check for ansible:
```
bash-4.4# cat sydney-1.out.thegabba.brutecleanup 
Command used:
./cleanup-oracle.sh --ora-version 19 --inventory-file /etc/files_needed_for_tk/nonrac-inv --yes-i-am-sure --ora-disk-mgmt udev --ora-swlib-path /u01/oracle_install --ora-asm-disks /etc/files_needed_for_tk/nonrac-asm.json --ora-data-mounts /etc/files_needed_for_tk/nonrac-datamounts.json

Running with parameters from command line or environment variables:

INVENTORY_FILE=/etc/files_needed_for_tk/nonrac-inv
ORA_ASM_DISKS=/etc/files_needed_for_tk/nonrac-asm.json
ORA_DATA_MOUNTS=/etc/files_needed_for_tk/nonrac-datamounts.json
ORA_DISK_MGMT=udev
ORA_ROLE_SEPARATION=TRUE
ORA_STAGING=/u01/oracle_install
ORA_SWLIB_PATH=/u01/oracle_install
ORA_VERSION=19.3.0.0.0

Ansible params: 
Ansible executable not found in path <===========
bash-4.4# 
```
Reason is that container images are typically lightweight and the fact that there is no `which` in the image tripped up `cleanup-oracle.sh`  [(due to the code at)](https://github.com/google/bms-toolkit/blob/master/cleanup-oracle.sh#L195-L201):
```
ANSIBLE_PLAYBOOK=`which ansible-playbook 2> /dev/null`
if [ $? -ne 0 ]; then
    echo "Ansible executable not found in path"
    exit 3
else
    echo "Found Ansible at $ANSIBLE_PLAYBOOK"
fi
```

The successful run after the proposed changes in this PR is as follows:
```
bash-4.4# /root/bms-toolkit/cleanup-oracle.sh --ora-version 19 --inventory-file /etc/files_needed_for_tk/nonrac-inv --yes-i-am-sure --ora-disk-mgmt udev --ora-swlib-path /u01/oracle_install --ora-asm-disks /etc/files_needed_for_tk/nonrac-asm.json --ora-data-mounts /etc/files_needed_for_tk/nonrac-datamounts.json
Command used:
/root/bms-toolkit/cleanup-oracle.sh --ora-version 19 --inventory-file /etc/files_needed_for_tk/nonrac-inv --yes-i-am-sure --ora-disk-mgmt udev --ora-swlib-path /u01/oracle_install --ora-asm-disks /etc/files_needed_for_tk/nonrac-asm.json --ora-data-mounts /etc/files_needed_for_tk/nonrac-datamounts.json

Running with parameters from command line or environment variables:

INVENTORY_FILE=/etc/files_needed_for_tk/nonrac-inv
ORA_ASM_DISKS=/etc/files_needed_for_tk/nonrac-asm.json
ORA_DATA_MOUNTS=/etc/files_needed_for_tk/nonrac-datamounts.json
ORA_DISK_MGMT=udev
ORA_ROLE_SEPARATION=TRUE
ORA_STAGING=/u01/oracle_install
ORA_SWLIB_PATH=/u01/oracle_install
ORA_VERSION=19.3.0.0.0

Ansible params: 

Running Ansible playbook: ansible-playbook -i /etc/files_needed_for_tk/nonrac-inv  brute-cleanup.yml

PLAY [dbasm] *******************************************************************************************************************************************************************

TASK [Gathering Facts] *********************************************************************************************************************************************************
```