### PR TITLE
Checking root for all of stdout_lines

### DIFF
--- a/check-instance.yml
+++ b/check-instance.yml
@@ -66,7 +66,7 @@
 
     - name: Fail if unable to sudo to root on target
       assert:
-        that: "rawrc.stdout_lines[0] == 'root'"
+        that: "'root' in rawrc.stdout_lines"
         fail_msg: "The account {{ ansible_user }} used to connect does not have sudo privileges to root"
         success_msg: "The account {{ ansible_user }} used to connect has sudo root privileges, continuing"
 


### PR DESCRIPTION
Existing check is too narrow and trips up on warnings like:
```
TASK [output rawrc] ************************************************************************************************************************************************************
ok: [linuxserver44.orcl] => {
    "rawrc": {
        "changed": false,
        "failed": false,
        "rc": 0,
        "stderr": "Shared connection to 172.16.30.1 closed.\r\n",
        "stderr_lines": [
            "Shared connection to 172.16.30.1 closed."
        ],
        "stdout": "/etc/profile.d/lang.sh: line 19: warning: setlocale: LC_CTYPE: cannot change locale (C.UTF-8)\r\nroot\r\n",
        "stdout_lines": [
            "/etc/profile.d/lang.sh: line 19: warning: setlocale: LC_CTYPE: cannot change locale (C.UTF-8)",
            "root"
        ]
    }
}
```

I have verified that the user ansible9 in the BMS host is indeed having sudo privs:
```bash
[ansible9@linuxserver44 ~]$ sudo -u root whoami
root
```