### PR TITLE
Fix Python 3 compatibility bug 

### DIFF
--- a/roles/ora-host/tasks/main.yml
+++ b/roles/ora-host/tasks/main.yml
@@ -319,15 +319,15 @@
   become: yes
   become_user: root
   blockinfile:
-    block: "ACTION==\"add|change\", ENV{DM_UUID}==\"{{ item }}\", SYMLINK+=\"{{ path_udev }}/{{ uuid_result[item] | json_query ('[*].name') | list | join(', ') }}\", GROUP=\"{{ grid_group }}\", OWNER=\"{{ grid_user }}\", MODE=\"0660\""
+    block: "ACTION==\"add|change\", ENV{DM_UUID}==\"{{ item.key }}\", SYMLINK+=\"{{ path_udev }}/{{ uuid_result[item.key] | json_query ('[*].name') | list | join(', ') }}\", GROUP=\"{{ grid_group }}\", OWNER=\"{{ grid_user }}\", MODE=\"0660\""
     path: "/etc/udev/rules.d/99-oracle-asmdevices.rules"
-    marker: "# {mark} ASM disk udev rules for {{ uuid_result[item] | json_query ('[*].blk_device') | list | join(', ') }}"
+    marker: "# {mark} ASM disk udev rules for {{ uuid_result[item.key] | json_query ('[*].blk_device') | list | join(', ') }}"
     create: yes
   register: udevRules
   when:
     - uuid_result is defined
-  with_items:
-    - "{{ uuid_result.keys() }}"
+  with_dict:
+    - "{{ uuid_result }}"
   tags: udev_mpath
 
 - name: (udev) reload rules


### PR DESCRIPTION
(Described also with additional snippets in (internal) https://b.corp.google.com/issues/202240337#comment16 through comment#21)

Got into a situation where for the same given asm_disk.json, data_mount.json config files input to the toolkit, targetted to be run on the very same BMX host, we had a successful vs failure case:
* successful: when run from existing control-node / GCP VM, ansible version 2.9.25, Python version 2.7.5
* failure: when run from a GKE pod, ansible version 2.9.25, Python version 3.8.6

The failure message was:
```bash
TASK [ora-host : (udev) Add ASM mpath disk rules on BM (udev rules file)] ******
fatal: [bmshost.orcl]: FAILED! => {"msg": "Unexpected templating type error occurred on (ACTION==\"add|change\",
 ENV{DM_UUID}==\"{{ item }}\", SYMLINK+=\"{{ path_udev }}/{{ uuid_result[item] | json_query ('[*].name') | list | 
join(', ') }}\", GROUP=\"{{ grid_group }}\", OWNER=\"{{ grid_user }}\", MODE=\"0660\"): 'NoneType' object is not 
iterable"}

PLAY RECAP *********************************************************************
bmshost.orcl         : ok=64   changed=4    unreachable=0    failed=1    skipped=24   rescued=0    ignored=0 
```

* After extensive debugging, it was found that using the key was the key :)
  * This is the reason: https://github.com/jdauphant/ansible-role-nginx/issues/150
  * Gist is: Python3 breaks `with_items: <dict>.keys()` and needs to be replaced with `with_dict: <dict>`
* This proposed fix is tested from both Python2 (where it didn't break prior to this proposed change) and Python3  (where this issue was exposed and the proposed solutions works) clients successfully.
* I have checked that there's no other instance of `with_items: <dict>.keys()` in our toolkit code that can lead to this.