### PR TITLE
Fix -rolling argument to auatchauto apply

### DIFF
--- a/roles/patch/tasks/rac-opatch.yml
+++ b/roles/patch/tasks/rac-opatch.yml
@@ -196,7 +196,7 @@
   tags: rac-opatch,stop-home
 
 - name: rac-opatch | Run GI opatch apply
-  command: "{{ grid_home }}/OPatch/{{ patch.method }} {{ '-ocmrf {{ swlib_unzip_path }}/ocm.rsp' if patch.ocm else '' }} {{ ' -nonrolling' if groups['dbasm'] | length==1 else ' -rolling' }}"
+  command: "{{ grid_home }}/OPatch/{{ patch.method }} {{ '-ocmrf {{ swlib_unzip_path }}/ocm.rsp' if patch.ocm else '' }} {{ '' if patch.method=='opatchauto apply' else ( ' -nonrolling' if groups['dbasm'] | length==1 else ' -rolling' ) }}"
   args:
     chdir: "{{ swlib_unzip_path }}/{{ patch.patchnum }}{{ patch.patch_subdir }}"
   loop: "{{ gi_patches | json_query('[?release==`'+ oracle_rel +'`]') }}"


### PR DESCRIPTION
`opatch apply` takes a `-rolling` or `-nonrolling` argument, and the
patching code sets it to `-rolling` for RAC installs and `-nonrolling`
for non-RAC installs.  `opatchauto`, however, does _not_ take such an
argument and will fail with a cryptic 
`OPATCHAUTO-72050: Failed while retrieving system information.` 
error if the flag is given.

This issue appears to have bene introduced in the patch refactoring in
May 2021, and the fix is relatively simple:  don't add the argument for
`opatchauto` patches.

Note this PR is based on the octpsu branch from PR #102 

Sample output:
Before patch: https://paste.googleplex.com/6024404149469184?raw
After patch: https://paste.googleplex.com/5688927173214208?raw