### PR TITLE
Populate oracle-rel when running install-sw.yml

### DIFF
--- a/install-sw.yml
+++ b/install-sw.yml
@@ -13,6 +13,13 @@
 # limitations under the License.
 
 ---
+- name: Populate variables
+  hosts: dbasm
+  tasks:
+  - include_role:
+      name: common
+      tasks_from: populate-vars.yml
+  tags: populate-vars
 - hosts: dbasm
   remote_user: "{{ grid_user }}"
   become: yes


### PR DESCRIPTION
bms-toolkit uses a series of "top-level" playbooks, which are run sequentially by scripts like `install-oracle.sh`.  As they're separate ansible-playbook runs, variables aren't persisted between calls.  One such variables is `oracle_rel`, which defines the actual release to install, rather than the default "latest" value.  This value is set in `populate-vars.yml`, in turn included from top-level playbooks like `pre-host.yml`, `check-swlib.yml`, and `patch.yml`.

A key playbook missing this setting is `install-sw.yml` where the actual software installation runs.  Specifically, the acutal install tasks in lines like https://github.com/google/bms-toolkit/blob/41333ce0b588106f2c556f34636e898807ce5fd3/roles/rac-db-setup/tasks/rac-db-install.yml#L51 reference oracle_rel, but with the default value of `latest`, they will not match any of the releases in `gi_patches` or `rdbms_patches`.  So we simply need to include, and resolve, releases again when running install-sw.yml.

Auditing references to `oracle_rel`, I found one more reference:  in https://github.com/google/bms-toolkit/blob/41333ce0b588106f2c556f34636e898807ce5fd3/roles/db-create/tasks/rac-db-create.yml#L303.  However this check only validates if oracle_rel=="base", which doesn't require additional resolution, so I'll leave that as-is.