### PR TITLE
Use wipefs to clear out user data disks

### DIFF
--- a/roles/brute-ora-cleanup/tasks/main.yml
+++ b/roles/brute-ora-cleanup/tasks/main.yml
@@ -68,6 +68,7 @@
     - tnslsnr
     - agent13c
     - ohasd
+    - orachkscheduler
     - OSWatcher
     - PROTOCOL=beq
     - '\\+ASM'
@@ -95,6 +96,7 @@
     - tnslsnr
     - agent13c
     - ohasd
+    - orachkscheduler
     - OSWatcher
     - PROTOCOL=beq
     - '\\+ASM'
@@ -134,8 +136,10 @@
     - /usr/local/bin/dbhome
     - /usr/local/bin/oraenv
     - /usr/local/bin/coraenv
+    - /etc/init.d/acfssihamount
     - /etc/init.d/ohasd
     - /etc/init.d/init.ohasd
+    - /etc/init.d/init.orachkscheduler
     - /etc/init.d/init.tfa
     - /etc/oracle
     - /etc/sysconfig/oracleasm-update
@@ -219,10 +223,10 @@
   with_items:
     - "{{ oracle_user_data_mounts }}"
 
-- name: Zero-out header in Oracle user data disks
+- name: Remove magic strings from Oracle user data disks
   become: yes
   become_user: root
-  command: "dd if=/dev/zero of={{ item.blk_device }} bs=1M count=100"
+  command: "wipefs --all --force {{ item.blk_device }}"
   with_items:
     - "{{ oracle_user_data_mounts }}"
 


### PR DESCRIPTION
As a attempt at addressing occasional "structure needs cleaning" errors when recreating XFS filesystems after a successful cleanup run ([example](https://oss.gprow.dev/view/gs/bmaas-testing-prow-bucket/pr-logs/pull/google_bms-toolkit/108/bms-toolkit-install/1537104195717435392)), here we replace dd with `wipefs`(8).  `wipefs` erases only the signatures (magic strings) of the detected filesystem on disk, reducing the likelyhood of leaving a filesystem inconsistent.

I can't test this directly (except for making sure it doesn't break cleanup entirely);  a manual testcase does seem to show that mkfs.xfs works properly with it:

```
[root@linuxserver44 ~]# dd if=/dev/zero of=testfs bs=1024k count=100
100+0 records in
100+0 records out
104857600 bytes (105 MB) copied, 0.0597355 s, 1.8 GB/s
[root@linuxserver44 ~]# losetup --find --show testfs
/dev/loop0
[root@linuxserver44 ~]# mkfs.xfs /dev/loop0
meta-data=/dev/loop0             isize=512    agcount=4, agsize=6400 blks
         =                       sectsz=512   attr=2, projid32bit=1
         =                       crc=1        finobt=0, sparse=0
data     =                       bsize=4096   blocks=25600, imaxpct=25
         =                       sunit=0      swidth=0 blks
naming   =version 2              bsize=4096   ascii-ci=0 ftype=1
log      =internal log           bsize=4096   blocks=855, version=2
         =                       sectsz=512   sunit=0 blks, lazy-count=1
realtime =none                   extsz=4096   blocks=0, rtextents=0
[root@linuxserver44 ~]# wipefs /dev/loop0
offset               type
----------------------------------------------------------------
0x0                  xfs   [filesystem]
                     UUID:  39a107dc-bcd3-44fc-a212-5806a4eb1d1e
[root@linuxserver44 ~]# mkfs.xfs /dev/loop0
mkfs.xfs: /dev/loop0 appears to contain an existing filesystem (xfs).
mkfs.xfs: Use the -f option to force overwrite.
[root@linuxserver44 ~]# wipefs -a /dev/loop0
/dev/loop0: 4 bytes were erased at offset 0x00000000 (xfs): 58 46 53 42
[root@linuxserver44 ~]# mkfs.xfs /dev/loop0
meta-data=/dev/loop0             isize=512    agcount=4, agsize=6400 blks
         =                       sectsz=512   attr=2, projid32bit=1
         =                       crc=1        finobt=0, sparse=0
data     =                       bsize=4096   blocks=25600, imaxpct=25
         =                       sunit=0      swidth=0 blks
naming   =version 2              bsize=4096   ascii-ci=0 ftype=1
log      =internal log           bsize=4096   blocks=855, version=2
         =                       sectsz=512   sunit=0 blks, lazy-count=1
realtime =none                   extsz=4096   blocks=0, rtextents=0
```

Additionally, I'm adding two more oracle initscripts that have appeared in more recent releases: `acfssihamount` and `orachkscheduler`.