### PR TITLE
Apply one off/OJVM patches separately from runInstaller

### DIFF
--- a/roles/rac-db-setup/tasks/rac-db-install.yml
+++ b/roles/rac-db-setup/tasks/rac-db-install.yml
@@ -77,11 +77,6 @@
   become: yes
   tags: rac-db,sw-unzip
 
-- name: rac-db-install | Set variable for OneOff patch
-  set_fact:
-    oneoff_patch_dirs: "{% set c = joiner(',') %}{% for p in rdbms_patches %}{% if p.release == oracle_rel %}{{ c() }}{{ swlib_unzip_path }}/{{ p.patchnum }}{{ p.patch_subdir }}{% endif %}{% endfor %}"
-  tags: rac-db,oneoff-patch
-
 - name: rac-db-install | Unzipping software
   become: yes
   become_user: "{{ oracle_user }}"
@@ -118,7 +113,7 @@
 
 - name: rac-db-install | Set installer command
   set_fact:
-    installer_command: "{{ runinstaller_loc }}/runInstaller -silent -waitforcompletion -responseFile {{ install_unzip_path }}/db_install.rsp {{ rel_patch | default('') }} {% if oneoff_patch_dirs|length > 0 %}-applyOneOffs {{ oneoff_patch_dirs }}{% endif %} {{ prereq_option }}"
+    installer_command: "{{ runinstaller_loc }}/runInstaller -silent -waitforcompletion -responseFile {{ install_unzip_path }}/db_install.rsp {{ rel_patch | default('') }} {{ prereq_option }}"
   tags: rac-db,rac-db-install
 
 - name: rac-db-install | Information
@@ -141,6 +136,28 @@
     msg:
       - "{{ install_rac_db }}"
   tags: rac-db,rac-db-install
+
+- name: rac-db-install | Apply one-off and OJVM patches
+  become: yes
+  become_user: "{{ oracle_user }}"
+  command: "{{ oracle_home }}/OPatch/{{ item.method }} -silent -oh {{ oracle_home }} {{ swlib_unzip_path }}/{{ item.patchnum }}{{ item.patch_subdir }}"
+  with_items:
+    - "{{ rdbms_patches }}"
+  when:
+    - item.release == oracle_rel
+  register: apply_oneoff
+  failed_when: "('OPatch succeeded' not in apply_oneoff.stdout) or
+                (apply_oneoff.rc not in [0,6,250])"
+  tags: rac-db,rac-db-install,opatch
+
+- name: rac-db-install | opatch output
+  debug:
+    msg:
+      - "{{ apply_oneoff.cmd }}"
+      - "{{ apply_oneoff.stdout_lines }}"
+  with_items: "{{ apply_oneoff.results }}"
+  when: item.changed
+  tags: rac-db,rac-db-install,opatch
 
 - name: rac-db-install | Run script root.sh
   become: yes

--- a/roles/rdbms-setup/tasks/rdbms-install.yml
+++ b/roles/rdbms-setup/tasks/rdbms-install.yml
@@ -49,11 +49,6 @@
   become: yes
   tags: rdbms-setup,sw-unzip
 
-- name: rdbms-install | Set variable for OneOff patch
-  set_fact:
-    oneoff_patch_dirs: "{% set c = joiner(',') %}{% for p in rdbms_patches %}{% if p.release == oracle_rel %}{{ c() }}{{ swlib_unzip_path }}/{{ p.patchnum }}{{ p.patch_subdir }}{% endif %}{% endfor %}"
-  tags: rdbms-setup,oneoff-patch
-
 - name: rdbms-install | Unzipping software
   become: yes
   become_user: "{{ oracle_user }}"
@@ -63,7 +58,7 @@
     remote_src: yes
   with_items:
     - "{{ osw.files }}"
-  tags: rdbms-setup,sw_unzip
+  tags: rdbms-setup,sw-unzip
 
 - name: rdbms-install | Create RDBMS response file script
   become: yes
@@ -104,7 +99,7 @@
 
 - name: rdbms-install | Set installer command
   set_fact:
-    installer_command: "{{ runinstaller_loc }}/runInstaller -silent -waitforcompletion -responseFile {{ swlib_unzip_path }}/db_install.rsp {{ rel_patch | default('') }} {% if oneoff_patch_dirs|length > 0 %}-applyOneOffs {{ oneoff_patch_dirs }}{% endif %} {{ prereq_option }}"
+    installer_command: "{{ runinstaller_loc }}/runInstaller -silent -waitforcompletion -responseFile {{ swlib_unzip_path }}/db_install.rsp {{ rel_patch | default('') }} {{ prereq_option }}"
   tags: rdbms-setup
 
 - name: rdbms-install | Information
@@ -128,6 +123,28 @@
       - "{{ install_db_software.stdout_lines }}"
     #verbosity: 1
   tags: rdbms-setup
+
+- name: rdbms-install | Apply one-off and OJVM patches
+  become: yes
+  become_user: "{{ oracle_user }}"
+  command: "{{ oracle_home }}/OPatch/{{ item.method }} -silent -oh {{ oracle_home }} {{ swlib_unzip_path }}/{{ item.patchnum }}{{ item.patch_subdir }}"
+  with_items:
+    - "{{ rdbms_patches }}"
+  when:
+    - item.release == oracle_rel
+  register: apply_oneoff
+  failed_when: "('OPatch succeeded' not in apply_oneoff.stdout) or
+                (apply_oneoff.rc not in [0,6,250])"
+  tags: rdbms-setup,opatch
+
+- name: rdbms-install | opatch output
+  debug:
+    msg:
+      - "{{ item.cmd }}"
+      - "{{ item.stdout_lines }}"
+  with_items: "{{ apply_oneoff.results }}"
+  when: item.changed
+  tags: rdbms-setup,opatch
 
 - name: rdbms-install | Run script orainstRoot.sh
   become: yes


### PR DESCRIPTION
Oracle bug 32816171, introduced in 19.11, causes OJVM one-off patch
application from runInstaller's `-applyOneOffs` to error out with make
errors.  A year later, this bug has yet to be fixed.  So to permit us to
add new patch updates to the toolkit, this patch removes `-applyOneOffs`
from the `runInstaller` call, and instead runs `opatch` separately for each
applicable patch.

Although this bug appear to affect only OJVM patches in 19.11+, to avoid
complicating the code flow too much, this change modifies patch application
for all one-off patches.

More background on the issue:
https://mikedietrichde.com/2021/04/22/oracle-19c-installation-with-19-11-0-ru-ojvm-and-some-other-fixes/