### PR TITLE
Refactor ntpd with chronyd

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1314,7 +1314,7 @@ NTP_PREF
 --ntp-pref
 </pre></p></td>
 <td>user defined - no default</td>
-<td>Preferred NTP server to use in /etc/ntp.conf.<br>
+<td>Preferred NTP server to use in /etc/chrony.conf.<br>
 <br>
 Optional: set only if you need to manually define an NTP server, instead of
 relying on the OS defaults.</td>

--- a/roles/base-provision/defaults/main.yml
+++ b/roles/base-provision/defaults/main.yml
@@ -20,7 +20,7 @@ etc_hosts_ip: "{% if 'virtualbox' in ansible_virtualization_type %}{{ ansible_al
 install_os_packages: true
 
 packages:
-  - ntp
+  - chrony
   - bind-utils
   - unzip
   - expect

--- a/roles/base-provision/handlers/main.yml
+++ b/roles/base-provision/handlers/main.yml
@@ -17,5 +17,5 @@
 - name: restart dnsmasq
   service: name=dnsmasq state=restarted
 
-- name: restart ntpd
-  service: name=ntpd state=restarted
+- name: restart chronyd
+  service: name=chronyd state=restarted

--- a/roles/base-provision/tasks/main.yml
+++ b/roles/base-provision/tasks/main.yml
@@ -29,6 +29,19 @@
   shell: pidof -x /usr/bin/yum /bin/yum | xargs -t -r -n 1 kill -INT
   tags: os_packages
 
+- name: Remove ntpd package
+  package:
+    name: ntp
+    state: absent
+    lock_timeout: 180
+  tags: ntp
+
+- name: Remove ntp conf
+  file:
+    path: /etc/ntp.conf
+    state: absent
+  tags: ntp
+
 - name: Disable avahi daemon
   systemd:
     name: "{{ item }}"
@@ -36,6 +49,7 @@
     state: stopped
   when:
     cluster_name is defined
+  ignore_errors: yes
   with_items:
     - avahi-daemon.socket
     - avahi-daemon.service

--- a/roles/base-provision/tasks/main.yml
+++ b/roles/base-provision/tasks/main.yml
@@ -29,19 +29,6 @@
   shell: pidof -x /usr/bin/yum /bin/yum | xargs -t -r -n 1 kill -INT
   tags: os_packages
 
-- name: Remove chrony package
-  package:
-    name: chrony
-    state: absent
-    lock_timeout: 180
-  tags: ntp
-
-- name: Remove chrony rpmsave
-  file:
-    path: /etc/chrony.conf.rpmsave
-    state: absent
-  tags: ntp
-
 - name: Disable avahi daemon
   systemd:
     name: "{{ item }}"
@@ -61,26 +48,19 @@
     lock_timeout: 180
   tags: os_packages
 
-- name: Update OPTIONS in /etc/sysconfig/ntpd
-  lineinfile:
-    dest: /etc/sysconfig/ntpd
-    regexp: '^OPTIONS='
-    line: 'OPTIONS="{{ ntp_options }}"'
-  notify: restart ntpd
-
 - name: Add ntp preferred server
   blockinfile:
-    path: /etc/ntp.conf
+    path: /etc/chrony.conf
     marker: "# {mark} ANSIBLE MANAGED BLOCK"
     insertafter: '^server '
     block: "server {{ ntp_preferred }} prefer iburst"
     state: "{{ (ntp_preferred != \"\" ) | ternary('present', 'absent') }}"
-  notify: restart ntpd
+  notify: restart chronyd
   tags: ntp
 
-- name: Make sure ntp is running
+- name: Make sure chronyd is running
   service:
-    name: ntpd
+    name: chronyd
     state: started
     enabled: yes
   tags: ntp


### PR DESCRIPTION
ntpd has been deprecated in favor of chronyd from EL 8.x
Chronyd has been around for some time as a functionally superior alternative for ntpd. 

With this change, we are uniformly using chrony to implement Oracle's NTP synchronization.
The proposed code changes have been tested successfully (internal: http://b/239771476) on an EL8.5 OEL host against 19c.

Testing it against a RHEL7.7 host with the prowjob with this PR.