### PR TITLE
Add asmcmd fixup for 12.2 RAC install

### DIFF
--- a/roles/rac-gi-setup/tasks/rac-gi-install.yml
+++ b/roles/rac-gi-setup/tasks/rac-gi-install.yml
@@ -185,6 +185,18 @@
       - "{{ install_rac_gi.stdout_lines }}"
   tags: rac-gi,rac-gi-install
 
+- name: rac-gi-install | Fix up asmcmd in 12.2 (MOS note 2748316.1)
+  become: yes
+  become_user: "{{ grid_user }}"
+  register: fixup_asmcmd
+  shell: "make -f ins_rdbms.mk client_sharedlib libasmclntsh12.ohso libasmperl12.ohso ORACLE_HOME={{ grid_home }}"
+  args:
+    chdir: "{{ grid_home }}/rdbms/lib"
+  environment:
+    ORACLE_HOME: "{{ grid_home }}"
+  when: oracle_ver == '12.2.0.1.0'
+  tags: rac-gi,rac-gi-install
+
 - name: rac-gi-install | Run script orainstRoot.sh
   become: yes
   become_user: root


### PR DESCRIPTION
Recent versions of Oracle 12.2 have a non-functional `asmcmd` executable
(MOS note 2748316.1);  among other things, it triggers a failure in the
last step of orainstRoot.sh, where a check of diskgroups, using asmcmd
internally, fails.  With 12.2 no longer having error correction support,
this issue has not been fixed in the 12.2 line.  Fortunately MOS note
2748316.1 presents a workaround by running a relink of client shared
libraries and ASM/perl libraries.  In our case the fix is even easier,
as we haven't brought up a cluster up yet, so have no need to do
prepatch and postpatch steps.

Output with error:

https://gist.github.com/mfielding/6e0fde41cfee2e901be38ea9ab5389c1

Output after fix:

https://gist.github.com/mfielding/cb47aa851531d5acde12b1412c37319c