### PR TITLE
Ignore errors when cleaning up mountpoints

### DIFF
--- a/roles/brute-ora-cleanup/tasks/main.yml
+++ b/roles/brute-ora-cleanup/tasks/main.yml
@@ -220,7 +220,10 @@
     src: "{{ item.blk_device }}1"
     path: "{{ item.mount_point }}"
     state: absent
-  ignore_errors: true
+  register: fstab_result
+  failed_when:
+    - fstab_result.rc != 0
+    - "'Directory not empty' not in fstab_result.stderr"
   with_items:
     - "{{ oracle_user_data_mounts }}"
 

--- a/roles/brute-ora-cleanup/tasks/main.yml
+++ b/roles/brute-ora-cleanup/tasks/main.yml
@@ -222,8 +222,8 @@
     state: absent
   register: fstab_result
   failed_when:
-    - fstab_result.rc != 0
-    - "'Directory not empty' not in fstab_result.stderr"
+    - fstab_result is failed
+    - "'Directory not empty' not in fstab_result.module_stdout"
   with_items:
     - "{{ oracle_user_data_mounts }}"
 

--- a/roles/brute-ora-cleanup/tasks/main.yml
+++ b/roles/brute-ora-cleanup/tasks/main.yml
@@ -220,6 +220,7 @@
     src: "{{ item.blk_device }}1"
     path: "{{ item.mount_point }}"
     state: absent
+  ignore_errors: true
   with_items:
     - "{{ oracle_user_data_mounts }}"
 


### PR DESCRIPTION
I ran into an error case during the cleanup of mountpoints:

```
TASK [brute-ora-cleanup : Remove Oracle user data devices from fstab] **********
failed: [linuxserver44] (item={u'mount_point': u'/u01', u'blk_device': u'/dev/mapper/sw-u01', u'name': u'u01', u'mount_opts': u'defaults', u'purpose': u'software', u'fstype': u'xfs'}) => {"ansible_loop_var": "item", "changed": false, "item": {"blk_device": "/dev/mapper/sw-u01", "fstype": "xfs", "mount_opts": "defaults", "mount_point": "/u01", "name": "u01", "purpose": "software"}, "msg": "Error rmdir /u01: [Errno 39] Directory not empty: '/u01'"}
```

One might wonder: why would removal of a mount return a `directory not empty` error?  It's because a mount removal not only unmounts, but also runs `rmdir` on the mountpoint.  And, in my case, there was content under /u01 in the root filesystem.  While it's bad practice to files that are [covered up](https://superuser.com/questions/200685/what-does-linux-do-with-existing-files-in-a-mount-point) by a mountpoint, it's also not worth aborting a cleanup run.  (And is probably harmless for future installs;  the content would just be covered up again.). So in the spirit of brute-force work, let's simply tell Ansible to ignore errors when removing mounts.