### PR TITLE
fix package related issues for OEL8.5

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -265,8 +265,8 @@ The target database server(s) must be running a version of Linux that is
 certified for Oracle Database. The toolkit currently supports the following
 certified OS versions:
 
-- Red Hat Enterprise Linux (RHEL) 7 (versions 7.3 and up).
-- Oracle Linux (OL) 7 (versions 7.3 and up).
+- Red Hat Enterprise Linux (RHEL) 7 and 8 (versions 7.3 and up).
+- Oracle Enterprise Linux (OEL) 7 and 8 (versions 7.3 and up).
 
 For more information about Oracle-supported platforms see the Oracle
 certification matrix in the "My Oracle Support" (MOS) site (sign in required):

--- a/roles/ora-host/defaults/main.yml
+++ b/roles/ora-host/defaults/main.yml
@@ -72,7 +72,7 @@ oracle_required_rpms:
   - xorg-x11-utils
   - xorg-x11-xauth
 
-oracle_required_rpms_oel8:
+oracle_required_rpms_el8:
   - bc
   - binutils
   - cpp

--- a/roles/ora-host/defaults/main.yml
+++ b/roles/ora-host/defaults/main.yml
@@ -72,6 +72,62 @@ oracle_required_rpms:
   - xorg-x11-utils
   - xorg-x11-xauth
 
+oracle_required_rpms_oel8:
+  - bc
+  - binutils
+  - cpp
+  - gcc
+  - gcc-c++
+  - glibc-devel
+  - glibc-headers
+  - gssproxy
+  - kernel-headers
+  - keyutils
+  - ksh
+  - libaio-devel
+  - libbasicobjects
+  - libcollection
+  - libdmx
+  - libevent
+  - libICE
+  - libini_config
+  - libmpc
+  - libnfsidmap
+  - libpath_utils
+  - libref_array
+  - libSM
+  - libstdc++-devel
+  - libtirpc
+  - libverto-libevent
+  - libXi
+  - libXinerama
+  - libXmu
+  - libXrandr
+  - libXrender
+  - libXt
+  - libXtst
+  - libXv
+  - libXxf86dga
+  - libXxf86misc
+  - libXxf86vm
+  - mailx
+  - make
+  - mpfr
+  - nfs-utils
+  - psmisc
+  - quota
+  - quota-nls
+  - rpcbind
+  - smartmontools
+  - sysstat
+  - xorg-x11-utils
+  - xorg-x11-xauth
+  - libnsl
+  - libnsl.i686
+  - libnsl2
+  - libnsl2.i686  
+
+
 sysctl_entries:
   - { name: "fs.aio-max-nr", value: "1048576" }
   - { name: "fs.file-max", value: "6815744" }

--- a/roles/ora-host/tasks/main.yml
+++ b/roles/ora-host/tasks/main.yml
@@ -80,6 +80,13 @@
   when:
     - install_os_packages|bool and ansible_distribution == 'OracleLinux'
 
+- name: Stat OL8 repo
+  stat:
+    path: /etc/yum.repos.d/oracle-linux-ol8.repo
+  register: oraclelinux_repo_oel8
+  when:
+    - install_os_packages|bool and ansible_distribution == 'OracleLinux'
+
 - name: Install Oracle required packages (base/non-rhui config) for OEL7
   yum:
     name: "{{ oracle_required_rpms }}"
@@ -88,6 +95,16 @@
   when:
     - install_os_packages|bool and ansible_distribution == 'OracleLinux' and ansible_distribution_major_version == '7'
     - oraclelinux_repo.stat.exists|bool
+  tags: os-packages
+
+- name: Install Oracle required packages (base/non-rhui config) for OEL8
+  yum:
+    name: "{{ oracle_required_rpms_oel8 }}"
+    state: present
+    lock_timeout: 180
+  when:
+    - install_os_packages|bool and ansible_distribution == 'OracleLinux' and ansible_distribution_major_version == '8'
+    - oraclelinux_repo_oel8.stat.exists|bool
   tags: os-packages
 
 - name: Install Oracle required packages (rhui config)

--- a/roles/ora-host/tasks/main.yml
+++ b/roles/ora-host/tasks/main.yml
@@ -99,7 +99,7 @@
 
 - name: Install Oracle required packages (base/non-rhui config) for OEL8
   yum:
-    name: "{{ oracle_required_rpms_oel8 }}"
+    name: "{{ oracle_required_rpms_el8 }}"
     state: present
     lock_timeout: 180
   when:

--- a/roles/rac-db-setup/tasks/rac-db-install.yml
+++ b/roles/rac-db-setup/tasks/rac-db-install.yml
@@ -153,10 +153,8 @@
 - name: rac-db-install | opatch output
   debug:
     msg:
-      - "{{ apply_oneoff.cmd }}"
-      - "{{ apply_oneoff.stdout_lines }}"
-  with_items: "{{ apply_oneoff.results }}"
-  when: item.changed
+      - "{{ apply_oneoff }}"
+  ignore_errors: yes
   tags: rac-db,rac-db-install,opatch
 
 - name: rac-db-install | Run script root.sh

--- a/roles/rac-db-setup/tasks/rac-db-install.yml
+++ b/roles/rac-db-setup/tasks/rac-db-install.yml
@@ -153,7 +153,10 @@
 - name: rac-db-install | opatch output
   debug:
     msg:
-      - "{{ apply_oneoff }}"
+      - "{{ item.cmd }}"
+      - "{{ item.stdout_lines }}"
+  with_items: "{{ apply_oneoff.results }}"
+  when: item.changed
   ignore_errors: yes
   tags: rac-db,rac-db-install,opatch
 


### PR DESCRIPTION
the `install-oracle.sh` utility failed with, possibly a EL8 missing library error:
```
...
TASK [rac-gi-setup : rac-gi-install | Information] *****************************
ok: [at-00010-svr002] => {
    "msg": "Using installer cmd: /u01/app/19.3.0/grid/gridSetup.sh -silent -responseFile /u01/app/19.3.0/grid/gridsetup.rsp  -applyRU /u01/oracle_install/34160854/34130714 -J-Doracle.install.mgmtDB=false -J-Doracle.install.mgmtDB.CDB=false -J-Doracle.install.crs.enableRemoteGIMR=false -ignorePrereqFailure"
}

TASK [rac-gi-setup : rac-gi-install | Run installer] ***************************
fatal: [at-00010-svr002]: FAILED! => {"changed": true, "cmd": ["/u01/app/19.3.0/grid/gridSetup.sh", "-silent", "-responseFile", "/u01/app/19.3.0/grid/gridsetup.rsp", "-applyRU", "/u01/oracle_install/34160854/34130714", "-J-Doracle.install.mgmtDB=false", "-J-Doracle.install.mgmtDB.CDB=false", "-J-Doracle.install.crs.enableRemoteGIMR=false", "-ignorePrereqFailure"], "delta": "0:00:00.015317", "end": "2022-08-18 15:58:29.236122", "failed_when_result": true, "msg": "non-zero return code", "rc": 127, "start": "2022-08-18 15:58:29.220805", "stderr": "/u01/app/19.3.0/grid/perl/bin/perl: error while loading shared libraries: libnsl.so.1: cannot open shared object file: No such file or directory", "stderr_lines": ["/u01/app/19.3.0/grid/perl/bin/perl: error while loading shared libraries: libnsl.so.1: cannot open shared object file: No such file or directory"], "stdout": "", "stdout_lines": []}
```

Manual reproduction:
```
[root@at-00010-svr002 ~]# /u01/app/19.3.0/grid/gridSetup.sh -silent -responseFile /u01/app/19.3.0/grid/gridsetup.rsp  -applyRU /u01/oracle_install/34160854/34130714 -J-Doracle.install.mgmtDB=false -J-Doracle.install.mgmtDB.CDB=false -J-Doracle.install.crs.enableRemoteGIMR=false -ignorePrereqFailure
/u01/app/19.3.0/grid/perl/bin/perl: error while loading shared libraries: 
libnsl.so.1: cannot open shared object file: No such file or directory

[root@at-00010-svr002 ~]# 
```

Research details:
* Installation of Patch 33115009 reports a possible conflict between libnsl.so.1 and libnsl.so.2 (Doc ID 2854326.1)
* Deploying 13c Agent on RHEL 8 fails with "error while loading shared libraries: libnsl.so.1" (Doc ID 2623611.1)

Attempting to: `Install OS library libnsl.so.1` per the 2nd metalink note above.

Clearly the dependency was missing (`libnsl.so.1 => not found`):
```
[root@at-00010-svr002 ~]# ldd /u01/app/19.3.0/grid/perl/bin/perl
	linux-vdso.so.1 (0x00007ffee7faa000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007fd39352d000)
	libnsl.so.1 => not found
	libdl.so.2 => /lib64/libdl.so.2 (0x00007fd393329000)
	libm.so.6 => /lib64/libm.so.6 (0x00007fd392fe4000)
	libcrypt.so.1 => /lib64/libcrypt.so.1 (0x00007fd392dbb000)
	libutil.so.1 => /lib64/libutil.so.1 (0x00007fd392bb7000)
	libc.so.6 => /lib64/libc.so.6 (0x00007fd3927f2000)
	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007fd3925d9000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fd39374d000)

```

The rpms were installed by introducing these changes:
```
✔ ~/mydrive/bmaas/el85/bms-toolkit [el85 ↑·3|✚ 6…2] 
10:58 $ git diff roles/ora-host/defaults/main.yml
diff --git a/roles/ora-host/defaults/main.yml b/roles/ora-host/defaults/main.yml
index 68e87a7..baed153 100644
--- a/roles/ora-host/defaults/main.yml
+++ b/roles/ora-host/defaults/main.yml
@@ -72,6 +72,13 @@ oracle_required_rpms:
   - xorg-x11-utils
   - xorg-x11-xauth
 
+oracle_required_rpms_oel8:
+  - libnsl
+  - libnsl.i686
+  - libnsl2
+  - libnsl2.i686  
+
+
 sysctl_entries:
   - { name: "fs.aio-max-nr", value: "1048576" }
   - { name: "fs.file-max", value: "6815744" }

✔ ~/mydrive/bmaas/el85/bms-toolkit [el85 ↑·3|✚ 6…2] 
11:00 $ git diff roles/ora-host/tasks/main.yml
diff --git a/roles/ora-host/tasks/main.yml b/roles/ora-host/tasks/main.yml
index b138b88..32313f5 100644
--- a/roles/ora-host/tasks/main.yml
+++ b/roles/ora-host/tasks/main.yml
@@ -80,6 +80,13 @@
   when:
     - install_os_packages|bool and ansible_distribution == 'OracleLinux'
 
+- name: Stat OL8 repo
+  stat:
+    path: /etc/yum.repos.d/oracle-linux-ol8.repo
+  register: oraclelinux_repo_oel8
+  when:
+    - install_os_packages|bool and ansible_distribution == 'OracleLinux'
+
 - name: Install Oracle required packages (base/non-rhui config) for OEL7
   yum:
     name: "{{ oracle_required_rpms }}"
@@ -90,6 +97,16 @@
     - oraclelinux_repo.stat.exists|bool
   tags: os-packages
 
+- name: Install Oracle required packages (base/non-rhui config) for OEL8
+  yum:
+    name: "{{ oracle_required_rpms_oel8 }}"
+    state: present
+    lock_timeout: 180
+  when:
+    - install_os_packages|bool and ansible_distribution == 'OracleLinux' and ansible_distribution_major_version == '8'
+    - oraclelinux_repo_oel8.stat.exists|bool
+  tags: os-packages
+
 - name: Install Oracle required packages (rhui config)
   yum:
     name: "{{ oracle_required_rpms }}"
```

The install went past the new changes and now the dependency check shows without error:
```
[root@at-00010-svr002 ~]# ldd /u01/app/19.3.0/grid/perl/bin/perl
	linux-vdso.so.1 (0x00007ffd12dae000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007ff7d34a5000)
	libnsl.so.1 => /lib64/libnsl.so.1 (0x00007ff7d328c000)   <==========
	libdl.so.2 => /lib64/libdl.so.2 (0x00007ff7d3088000)
	libm.so.6 => /lib64/libm.so.6 (0x00007ff7d2d06000)
	libcrypt.so.1 => /lib64/libcrypt.so.1 (0x00007ff7d2add000)
	libutil.so.1 => /lib64/libutil.so.1 (0x00007ff7d28d9000)
	libc.so.6 => /lib64/libc.so.6 (0x00007ff7d2514000)
	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007ff7d22fb000)
	/lib64/ld-linux-x86-64.so.2 (0x00007ff7d36c5000)

```

The install failed with:
```
Patch 34160635:
Cannot locate executable 'make', hence the Make Action is not applicable
'oracle.xag, 19.0.0.0.0': Cannot re-link target 'install_srvm' using make file '/u01/app/19.3.0/grid/srvm/lib/ins_srvm.mk'
Cannot locate executable 'make', hence the Make Action is not applicable
'oracle.xag, 19.0.0.0.0': Cannot re-link target 'install' using make file '/u01/app/19.3.0/grid/racg/lib/ins_has.mk'
]
CheckSystemCommandsAvailable :- [ Prerequisite Status: FAILED, Prerequisite output:
The details are:
Missing command :make]
```

Based on the following error ... :
```
TASK [ora-host : Install Oracle required generic packages (base/non-rhui config) for OEL8] ***
fatal: [at-00010-svr002]: FAILED! => {"changed": false, "failures": ["No package compat-libcap1 available.", "No package compat-libstdc++-33 available.", "No package tcp_wrappers available."], "msg": "Failed to install some of the specified packages", "rc": 1, "results": []}
```

... added the needed common rpms and then the GI RAC proceeded to success:
```
oracle_required_rpms_oel8:
  - bc
  - binutils
  - cpp
  - gcc
  - gcc-c++
  - glibc-devel
  - glibc-headers
  - gssproxy
  - kernel-headers
  - keyutils
  - ksh
  - libaio-devel
  - libbasicobjects
  - libcollection
  - libdmx
  - libevent
  - libICE
  - libini_config
  - libmpc
  - libnfsidmap
  - libpath_utils
  - libref_array
  - libSM
  - libstdc++-devel
  - libtirpc
  - libverto-libevent
  - libXi
  - libXinerama
  - libXmu
  - libXrandr
  - libXrender
  - libXt
  - libXtst
  - libXv
  - libXxf86dga
  - libXxf86misc
  - libXxf86vm
  - mailx
  - make
  - mpfr
  - nfs-utils
  - psmisc
  - quota
  - quota-nls
  - rpcbind
  - smartmontools
  - sysstat
  - xorg-x11-utils
  - xorg-x11-xauth
  - libnsl
  - libnsl.i686
  - libnsl2
  - libnsl2.i686  
```

The RAC GI install finished successfully