### PR TITLE
Ignore errors while patch application

### DIFF
--- a/roles/rac-db-setup/tasks/rac-db-install.yml
+++ b/roles/rac-db-setup/tasks/rac-db-install.yml
@@ -148,6 +148,7 @@
   register: apply_oneoff
   failed_when: "('OPatch succeeded' not in apply_oneoff.stdout) or
                 (apply_oneoff.rc not in [0,6,250])"
+  ignore_errors: yes
   tags: rac-db,rac-db-install,opatch
 
 - name: rac-db-install | opatch output

--- a/roles/rdbms-setup/tasks/rdbms-install.yml
+++ b/roles/rdbms-setup/tasks/rdbms-install.yml
@@ -135,6 +135,7 @@
   register: apply_oneoff
   failed_when: "('OPatch succeeded' not in apply_oneoff.stdout) or
                 (apply_oneoff.rc not in [0,6,250])"
+  ignore_errors: yes
   tags: rdbms-setup,opatch
 
 - name: rdbms-install | opatch output


### PR DESCRIPTION
Patch errors vary based on the exact underlying situation and can be fixed once the main run of the `install-oracle.sh` is completed.

Some of the recent errors I have seen are:
1)
```
TASK [rac-db-setup : rac-db-install | Apply one-off and OJVM patches] **********
failed: [at-00010-svr002] (item={'category': 'RU_Combo', 'base': '19.3.0.0.0', 'release': '19.16.0.0.220719', 'patchnum': '34160854', 'patchfile': 'p34160854_190000_Linux-x86-64.zip', 'patch_subdir': '/34086870', 'prereq_check': True, 'method': 'opatch apply', 'ocm': False, 'upgrade': True, 'md5sum': 'ocQvBx8Oqbnci3hf89CczA=='}) => {"ansible_loop_var": "item", "changed": true, "cmd": ["/u01/app/oracle/product/19.3.0/dbhome_1/OPatch/opatch", "apply", "-silent", "-oh", "/u01/app/oracle/product/19.3.0/dbhome_1", "/u01/oracle_install/34160854/34086870"], "delta": "0:01:35.767408", "end": "2022-09-22 07:07:54.969320", "failed_when_result": true, "item": {"base": "19.3.0.0.0", "category": "RU_Combo", "md5sum": "ocQvBx8Oqbnci3hf89CczA==", "method": "opatch apply", "ocm": false, "patch_subdir": "/34086870", "patchfile": "p34160854_190000_Linux-x86-64.zip", "patchnum": "34160854", "prereq_check": true, "release": "19.16.0.0.220719", "upgrade": true}, "msg": "non-zero return code", "rc": 73, "start": "2022-09-22 07:06:19.201912", "stderr": "OPatch failed to restore OH '/u01/app/oracle/product/19.3.0/dbhome_1'. Consult OPatch document to restore the home manually before proceeding.\nUtilSession failed: Re-link fails on target \"javavm_refresh\".", "stderr_lines": ["OPatch failed to restore OH '/u01/app/oracle/product/19.3.0/dbhome_1'. Consult OPatch document to restore the home manually before proceeding.", "UtilSession failed: Re-link fails on target \"javavm_refresh\"."], "stdout": "Oracle Interim Patch Installer version 12.2.0.1.32\nCopyright (c) 2022, Oracle Corporation.  All rights reserved.\n\n\nOracle Home       : /u01/app/oracle/product/19.3.0/dbhome_1\nCentral Inventory : /u01/app/oraInventory\n   from           : /u01/app/oracle/product/19.3.0/dbhome_1/oraInst.loc\nOPatch version    : 12.2.0.1.32\nOUI version       : 12.2.0.7.0\nLog file location : /u01/app/oracle/product/19.3.0/dbhome_1/cfgtoollogs/opatch/opatch2022-09-22_07-06-19AM_1.log\n\nVerifying environment and performing prerequisite checks...\nOPatch continues with these patches:   34086870  \n\nDo you want to proceed? [y|n]\nY (auto-answered by -silent)\nUser Responded with: Y\nAll checks passed.\n\nPlease shutdown Oracle instances running out of this ORACLE_HOME on the local system.\n(Oracle Home = '/u01/app/oracle/product/19.3.0/dbhome_1')\n\n\nIs the local system ready for patching? [y|n]\nY (auto-answered by -silent)\nUser Responded with: Y\nBacking up files...\nApplying interim patch '34086870' to OH '/u01/app/oracle/product/19.3.0/dbhome_1'\n\nPatching component oracle.javavm.server, 19.0.0.0.0...\n\nPatching component oracle.javavm.server.core, 19.0.0.0.0...\n\nPatching component oracle.rdbms.dbscripts, 19.0.0.0.0...\n\nPatching component oracle.rdbms, 19.0.0.0.0...\n\nPatching component oracle.javavm.client, 19.0.0.0.0...\nMake failed to invoke \"/usr/bin/make -f ins_rdbms.mk javavm_refresh ORACLE_HOME=/u01/app/oracle/product/19.3.0/dbhome_1 OPATCH_SESSION=apply\"....'make: perl: Command not found\nmake: *** [ins_rdbms.mk:573: javavm_refresh] Error 127\n'\n\nThe following make actions have failed :\n\nRe-link fails on target \"javavm_refresh\".\n\n\nDo you want to proceed? [y|n]\nN (auto-answered by -silent)\nUser Responded with: N\n\nRestoring \"/u01/app/oracle/product/19.3.0/dbhome_1\" to the state prior to running NApply...\nChecking if OPatch needs to invoke 'make' to restore some binaries...\nMake failed to invoke \"/usr/bin/make -f ins_rdbms.mk javavm_refresh ORACLE_HOME=/u01/app/oracle/product/19.3.0/dbhome_1 OPATCH_SESSION=apply\"....'make: perl: Command not found\nmake: *** [ins_rdbms.mk:573: javavm_refresh] Error 127\n'\n\n--------------------------------------------------------------------------------\nFailed to run make commands. Please contact Oracle Support.\n\nNApply was not able to restore the home.  Please invoke the following scripts:\n  - restore.[sh,bat]\n  - make.txt (Unix only)\nto restore the ORACLE_HOME.  They are located under \n\"/u01/app/oracle/product/19.3.0/dbhome_1/.patch_storage/NApply/2022-09-22_07-06-19AM\"\n\nLog file location: /u01/app/oracle/product/19.3.0/dbhome_1/cfgtoollogs/opatch/opatch2022-09-22_07-06-19AM_1.log\n\nOPatch failed with error code 73", "stdout_lines": ["Oracle Interim Patch Installer version 12.2.0.1.32", "Copyright (c) 2022, Oracle Corporation.  All rights reserved.", "", "", "Oracle Home       : /u01/app/oracle/product/19.3.0/dbhome_1", "Central Inventory : /u01/app/oraInventory", "   from           : /u01/app/oracle/product/19.3.0/dbhome_1/oraInst.loc", "OPatch version    : 12.2.0.1.32", "OUI version       : 12.2.0.7.0", "Log file location : /u01/app/oracle/product/19.3.0/dbhome_1/cfgtoollogs/opatch/opatch2022-09-22_07-06-19AM_1.log", "", "Verifying environment and performing prerequisite checks...", "OPatch continues with these patches:   34086870  ", "", "Do you want to proceed? [y|n]", "Y (auto-answered by -silent)", "User Responded with: Y", "All checks passed.", "", "Please shutdown Oracle instances running out of this ORACLE_HOME on the local system.", "(Oracle Home = '/u01/app/oracle/product/19.3.0/dbhome_1')", "", "", "Is the local system ready for patching? [y|n]", "Y (auto-answered by -silent)", "User Responded with: Y", "Backing up files...", "Applying interim patch '34086870' to OH '/u01/app/oracle/product/19.3.0/dbhome_1'", "", "Patching component oracle.javavm.server, 19.0.0.0.0...", "", "Patching component oracle.javavm.server.core, 19.0.0.0.0...", "", "Patching component oracle.rdbms.dbscripts, 19.0.0.0.0...", "", "Patching component oracle.rdbms, 19.0.0.0.0...", "", "Patching component oracle.javavm.client, 19.0.0.0.0...", "Make failed to invoke \"/usr/bin/make -f ins_rdbms.mk javavm_refresh ORACLE_HOME=/u01/app/oracle/product/19.3.0/dbhome_1 OPATCH_SESSION=apply\"....'make: perl: Command not found", "make: *** [ins_rdbms.mk:573: javavm_refresh] Error 127", "'", "", "The following make actions have failed :", "", "Re-link fails on target \"javavm_refresh\".", "", "", "Do you want to proceed? [y|n]", "N (auto-answered by -silent)", "User Responded with: N", "", "Restoring \"/u01/app/oracle/product/19.3.0/dbhome_1\" to the state prior to running NApply...", "Checking if OPatch needs to invoke 'make' to restore some binaries...", "Make failed to invoke \"/usr/bin/make -f ins_rdbms.mk javavm_refresh ORACLE_HOME=/u01/app/oracle/product/19.3.0/dbhome_1 OPATCH_SESSION=apply\"....'make: perl: Command not found", "make: *** [ins_rdbms.mk:573: javavm_refresh] Error 127", "'", "", "--------------------------------------------------------------------------------", "Failed to run make commands. Please contact Oracle Support.", "", "NApply was not able to restore the home.  Please invoke the following scripts:", "  - restore.[sh,bat]", "  - make.txt (Unix only)", "to restore the ORACLE_HOME.  They are located under ", "\"/u01/app/oracle/product/19.3.0/dbhome_1/.patch_storage/NApply/2022-09-22_07-06-19AM\"", "", "Log file location: /u01/app/oracle/product/19.3.0/dbhome_1/cfgtoollogs/opatch/opatch2022-09-22_07-06-19AM_1.log", "", "OPatch failed with error code 73"]}

```

2) 
```
TASK [rac-db-setup : rac-db-install | Apply one-off and OJVM patches] **********
failed: [at-00010-svr002] (item={'category': 'RU_Combo', 'base': '19.3.0.0.0', 'release': '19.16.0.0.220719', 'patchnum': '34160854', 'patchfile': 'p34160854_190000_Linux-x86-64.zip', 'patch_subdir': '/34086870', 'prereq_check': True, 'method': 'opatch apply', 'ocm': False, 'upgrade': True, 'md5sum': 'ocQvBx8Oqbnci3hf89CczA=='}) => {"ansible_loop_var": "item", "changed": true, "cmd": ["/u01/app/oracle/product/19.3.0/dbhome_1/OPatch/opatch", "apply", "-silent", "-oh", "/u01/app/oracle/product/19.3.0/dbhome_1", "/u01/oracle_install/34160854/34086870"], "delta": "0:00:00.015274", "end": "2022-09-22 09:30:17.407352", "failed_when_result": true, "item": {"base": "19.3.0.0.0", "category": "RU_Combo", "md5sum": "ocQvBx8Oqbnci3hf89CczA==", "method": "opatch apply", "ocm": false, "patch_subdir": "/34086870", "patchfile": "p34160854_190000_Linux-x86-64.zip", "patchnum": "34160854", "prereq_check": true, "release": "19.16.0.0.220719", "upgrade": true}, "msg": "non-zero return code", "rc": 1, "start": "2022-09-22 09:30:17.392078", "stderr": "/u01/app/oracle/product/19.3.0/dbhome_1/OPatch/opatch: line 133: dirname: command not found\n/u01/app/oracle/product/19.3.0/dbhome_1/OPatch/opatch: line 165: dirname: command not found\n/u01/app/oracle/product/19.3.0/dbhome_1/OPatch/opatch: line 195: uname: command not found\n/u01/app/oracle/product/19.3.0/dbhome_1/OPatch/opatch: line 228: cut: command not found\n/u01/app/oracle/product/19.3.0/dbhome_1/OPatch/opatch: line 244: id: command not found\n/u01/app/oracle/product/19.3.0/dbhome_1/OPatch/opatch: line 245: grep: command not found\n/u01/app/oracle/product/19.3.0/dbhome_1/OPatch/opatch: line 519: tr: command not found\n/u01/app/oracle/product/19.3.0/dbhome_1/OPatch/opatch: line 519: tr: command not found\n/u01/app/oracle/product/19.3.0/dbhome_1/OPatch/opatch: line 519: tr: command not found\n/u01/app/oracle/product/19.3.0/dbhome_1/OPatch/opatch: line 519: tr: command not found\n/u01/app/oracle/product/19.3.0/dbhome_1/OPatch/opatch: line 519: tr: command not found\n/u01/app/oracle/product/19.3.0/dbhome_1/OPatch/opatch: line 659: grep: command not found\n/u01/app/oracle/product/19.3.0/dbhome_1/OPatch/opatch: line 946: /scripts/opatch_jvm_discovery: No such file or directory", "stderr_lines": ["/u01/app/oracle/product/19.3.0/dbhome_1/OPatch/opatch: line 133: dirname: command not found", "/u01/app/oracle/product/19.3.0/dbhome_1/OPatch/opatch: line 165: dirname: command not found", "/u01/app/oracle/product/19.3.0/dbhome_1/OPatch/opatch: line 195: uname: command not found", "/u01/app/oracle/product/19.3.0/dbhome_1/OPatch/opatch: line 228: cut: command not found", "/u01/app/oracle/product/19.3.0/dbhome_1/OPatch/opatch: line 244: id: command not found", "/u01/app/oracle/product/19.3.0/dbhome_1/OPatch/opatch: line 245: grep: command not found", "/u01/app/oracle/product/19.3.0/dbhome_1/OPatch/opatch: line 519: tr: command not found", "/u01/app/oracle/product/19.3.0/dbhome_1/OPatch/opatch: line 519: tr: command not found", "/u01/app/oracle/product/19.3.0/dbhome_1/OPatch/opatch: line 519: tr: command not found", "/u01/app/oracle/product/19.3.0/dbhome_1/OPatch/opatch: line 519: tr: command not found", "/u01/app/oracle/product/19.3.0/dbhome_1/OPatch/opatch: line 519: tr: command not found", "/u01/app/oracle/product/19.3.0/dbhome_1/OPatch/opatch: line 659: grep: command not found", "/u01/app/oracle/product/19.3.0/dbhome_1/OPatch/opatch: line 946: /scripts/opatch_jvm_discovery: No such file or directory"], "stdout": "version_not_readable\nversion_not_readable", "stdout_lines": ["version_not_readable", "version_not_readable"]}
...ignoring
```

3)
```
2022-08-20 03:08:14,508 p=2051377 u=jcnarasimhan n=ansible | TASK [rdbms-setup : rdbms-install | Apply one-off and OJVM patches] ************
2022-08-20 03:08:14,509 p=2051377 u=jcnarasimhan n=ansible | failed: [linuxserver44.orcl] (item={'category': 'RU_Combo', 'base': '12.2.0.1.0', 'release': '12.2.0.1.220118', 'patchnum': '33559966', 'patchfile': 'p33559966_122010_Linux-x86-64.zip', 'patch_subdir': '/33561275', 'prereq_check': True, 'method': 'opatch apply', 'ocm': False, 'upgrade': True, 'md5sum': 'WBMRq104f5F6iZrmg727aw=='}) => {"ansible_loop_var": "item", "changed": true, "cmd": ["/u01/app/oracle/product/12.2.0/dbhome_1/OPatch/opatch", "apply", "-silent", "-oh", "/u01/app/oracle/product/12.2.0/dbhome_1", "/u01/oracle_install/33559966/33561275"], "delta": "0:00:02.752146", "end": "2022-08-20 03:08:13.461318", "failed_when_result": true, "item": {"base": "12.2.0.1.0", "category": "RU_Combo", "md5sum": "WBMRq104f5F6iZrmg727aw==", "method": "opatch apply", "ocm": false, "patch_subdir": "/33561275", "patchfile": "p33559966_122010_Linux-x86-64.zip", "patchnum": "33559966", "prereq_check": true, "release": "12.2.0.1.220118", "upgrade": true}, "msg": "non-zero return code", "rc": 73, "start": "2022-08-20 03:08:10.709172", "stderr": "UtilSession failed: Prerequisite check \"CheckMinimumOPatchVersion\" failed.", "stderr_lines": ["UtilSession failed: Prerequisite check \"CheckMinimumOPatchVersion\" failed."], "stdout": "Oracle Interim Patch Installer version 12.2.0.1.6\nCopyright (c) 2022, Oracle Corporation.  All rights reserved.\n\n\nOracle Home       : /u01/app/oracle/product/12.2.0/dbhome_1\nCentral Inventory : /u01/app/oraInventory\n   from           : /u01/app/oracle/product/12.2.0/dbhome_1/oraInst.loc\nOPatch version    : 12.2.0.1.6\nOUI version       : 12.2.0.1.4\nLog file location : /u01/app/oracle/product/12.2.0/dbhome_1/cfgtoollogs/opatch/opatch2022-08-20_03-08-10AM_1.log\n\nVerifying environment and performing prerequisite checks...\nPrerequisite check \"CheckMinimumOPatchVersion\" failed.\nThe details are:\n\n\nThe OPatch being used has version 12.2.0.1.6 while the following patch(es) require higher versions: \nPatch 33561275 requires OPatch version 12.2.0.1.28.\nPlease download latest OPatch from My Oracle Support.\n\nLog file location: /u01/app/oracle/product/12.2.0/dbhome_1/cfgtoollogs/opatch/opatch2022-08-20_03-08-10AM_1.log\n\nOPatch failed with error code 73", "stdout_lines": ["Oracle Interim Patch Installer version 12.2.0.1.6", "Copyright (c) 2022, Oracle Corporation.  All rights reserved.", "", "", "Oracle Home       : /u01/app/oracle/product/12.2.0/dbhome_1", "Central Inventory : /u01/app/oraInventory", "   from           : /u01/app/oracle/product/12.2.0/dbhome_1/oraInst.loc", "OPatch version    : 12.2.0.1.6", "OUI version       : 12.2.0.1.4", "Log file location : /u01/app/oracle/product/12.2.0/dbhome_1/cfgtoollogs/opatch/opatch2022-08-20_03-08-10AM_1.log", "", "Verifying environment and performing prerequisite checks...", "Prerequisite check \"CheckMinimumOPatchVersion\" failed.", "The details are:", "", "", "The OPatch being used has version 12.2.0.1.6 while the following patch(es) require higher versions: ", "Patch 33561275 requires OPatch version 12.2.0.1.28.", "Please download latest OPatch from My Oracle Support.", "", "Log file location: /u01/app/oracle/product/12.2.0/dbhome_1/cfgtoollogs/opatch/opatch2022-08-20_03-08-10AM_1.log", "", "OPatch failed with error code 73"]}

```
