### PR TITLE
Remove reference to reboots in the user guide

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -2348,7 +2348,6 @@ the following actions:
 -  Removes Oracle related directories and files.
 -  Removes Oracle software owner users and groups.
 -  Re-initializes ASM storage devices and uninstalls ASMlib if installed.
--  Reboots the server.
 
 **Important**: a destructive cleanup permanently deletes the databases and any data they
 contain. Any backups that are stored local to the server are also deleted. Backups


### PR DESCRIPTION
`cleanup-oracle.sh` doesn't actually reboot the server;  we've actually done a lot of work to avoid needing a slow and potentially risky reboot even when the install failed.