### PR TITLE
Remove diag mount from default data_mounts.json

### DIFF
--- a/data_mounts_config.json
+++ b/data_mounts_config.json
@@ -6,13 +6,5 @@
 	"fstype":"xfs",
 	"mount_point":"/u01",
 	"mount_opts":"nofail"
-    },
-    {
-        "purpose": "diag",
-	"blk_device": "/dev/BOGUS",
-	"name": "u02",
-	"fstype":"xfs",
-	"mount_point":"/u02",
-	"mount_opts":"nofail"
     }
 ]


### PR DESCRIPTION
Right now the toolkit doesn't actually use the `diag` mount for anything, so having it in the default config file is a bit confusing.  Removing it entirely.