### PR TITLE
Add missing parted dependency

### DIFF
--- a/roles/base-provision/defaults/main.yml
+++ b/roles/base-provision/defaults/main.yml
@@ -26,6 +26,7 @@ packages:
   - expect
   - wget
   - net-tools
+  - parted
 
 swap_blk_device: ""
 ntp_preferred: ""


### PR DESCRIPTION
The host-storage role runs the `parted` command to partition user mount devices.  But many OS minimal installs don't include this, resulting in the following error message:

```
TASK [host-storage : Partition Oracle user mount devices] *****************************************************************************************************************************************
failed: [toolkit-ol8] (item={u'mount_point': u'/u01', u'blk_device': u'/dev/sdd', u'name': u'u01', u'mount_opts': u'nofail', u'purpose': u'software', u'fstype': u'xfs'}) => {"ansible_loop_var": "item", "changed": false, "item": {"blk_device": "/dev/sdd", "fstype": "xfs", "mount_opts": "nofail", "mount_point": "/u01", "name": "u01", "purpose": "software"}, "msg": "Failed to find required executable parted in paths: /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin"}
```

Adding parted to the list of dependent packages to install.