### PR TITLE
Remove jinja2 references from when clauses

### DIFF
--- a/roles/rac-gi-setup/tasks/rac-asm-create.yml
+++ b/roles/rac-gi-setup/tasks/rac-asm-create.yml
@@ -48,7 +48,7 @@
     LD_LIBRARY_PATH: "{{ grid_home }}/lib:${LD_LIBRARY_PATH}"
   when:
     - asm_disk_management == "asmlib"
-    - created_dg is not search('{{ item.diskgroup }}')
+    - created_dg is not search(item.diskgroup)
   with_items:
     - "{{ asm_disks }}"
   register: create_dg
@@ -76,7 +76,7 @@
     LD_LIBRARY_PATH: "{{ grid_home }}/lib:${LD_LIBRARY_PATH}"
   when:
     - asm_disk_management == "udev"
-    - created_dg is not search('{{ item.diskgroup }}')
+    - created_dg is not search(item.diskgroup)
   with_items:
     - "{{ asm_disks }}"
   register: create_dg


### PR DESCRIPTION
Current ansible versions give a warning:

```
TASK [rac-gi-setup : rac-asm-create | Check available ASM disk groups] *********
ok: [toolkit-ol8]
[WARNING]: conditional statements should not include jinja2 templating
delimiters such as {{ }} or {% %}. Found: created_dg is not search('{{
item.diskgroup }}')
```

The fix is simple:  just referencing the item directly.