### PR TITLE
Add Perl environment variables when patching

### DIFF
--- a/roles/rac-db-setup/tasks/rac-db-install.yml
+++ b/roles/rac-db-setup/tasks/rac-db-install.yml
@@ -141,6 +141,9 @@
   become: yes
   become_user: "{{ oracle_user }}"
   command: "{{ oracle_home }}/OPatch/{{ item.method }} -silent -oh {{ oracle_home }} {{ swlib_unzip_path }}/{{ item.patchnum }}{{ item.patch_subdir }}"
+  environment:
+    PATH: "{{ oracle_home }}/perl/bin:$PATH"
+    PERL5LIB: "{{ oracle_home }}/perl/lib"
   with_items:
     - "{{ rdbms_patches }}"
   when:

--- a/roles/rac-db-setup/tasks/rac-db-install.yml
+++ b/roles/rac-db-setup/tasks/rac-db-install.yml
@@ -142,7 +142,7 @@
   become_user: "{{ oracle_user }}"
   command: "{{ oracle_home }}/OPatch/{{ item.method }} -silent -oh {{ oracle_home }} {{ swlib_unzip_path }}/{{ item.patchnum }}{{ item.patch_subdir }}"
   environment:
-    PATH: "{{ grid_home }}/perl/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+    PATH: "{{ oracle_home }}/perl/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
     PERL5LIB: "{{ oracle_home }}/perl/lib"
   with_items:
     - "{{ rdbms_patches }}"

--- a/roles/rac-db-setup/tasks/rac-db-install.yml
+++ b/roles/rac-db-setup/tasks/rac-db-install.yml
@@ -142,7 +142,7 @@
   become_user: "{{ oracle_user }}"
   command: "{{ oracle_home }}/OPatch/{{ item.method }} -silent -oh {{ oracle_home }} {{ swlib_unzip_path }}/{{ item.patchnum }}{{ item.patch_subdir }}"
   environment:
-    PATH: "{{ oracle_home }}/perl/bin:$PATH"
+    PATH: "{{ grid_home }}/perl/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
     PERL5LIB: "{{ oracle_home }}/perl/lib"
   with_items:
     - "{{ rdbms_patches }}"

--- a/roles/rdbms-setup/tasks/rdbms-install.yml
+++ b/roles/rdbms-setup/tasks/rdbms-install.yml
@@ -128,6 +128,9 @@
   become: yes
   become_user: "{{ oracle_user }}"
   command: "{{ oracle_home }}/OPatch/{{ item.method }} -silent -oh {{ oracle_home }} {{ swlib_unzip_path }}/{{ item.patchnum }}{{ item.patch_subdir }}"
+  environment:
+    PATH: "{{ oracle_home }}/perl/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+    PERL5LIB: "{{ oracle_home }}/perl/lib"  
   with_items:
     - "{{ rdbms_patches }}"
   when:


### PR DESCRIPTION
Post-patch relinking scripts sometimes call "perl".  If there is a perl operator in the base operating system, it typically works with that, but isn't ideal as the version and modules are likely different from Oracle's.  As per MOS note 2002334.1, patch application should put $ORACLE_HOME/perl/bin in the PATH and set PERL5LIB.  Doing so here.

On systems without an OS-level Perl, patching errors out completely:

```

TASK [rac-db-setup : rac-db-install | Apply one-off and OJVM patches] **********
failed: [toolkit-ol8] (item={u'category': u'RU_Combo', u'patchfile': u'p34449117_190000_Linux-x86-64.zip', u'upgrade': True, u'ocm': False, u'patchnum': u'34449117', u'md5sum': u'GAdowBq8IzvPAqD3wMnd/g==', u'prereq_check': True, u'base': u'19.3.0.0.0', u'release': u'19.17.0.0.221018', u'method': u'opatch apply', u'patch_subdir': u'/34411846'}) => {"ansible_loop_var": "item", "changed": true, "cmd": ["/u01/app/oracle/product/19.3.0/dbhome_1/OPatch/opatch", "apply", "-silent", "-oh", "/u01/app/oracle/product/19.3.0/dbhome_1", "/u01/oracle_install/34449117/34411846"], "delta": "0:01:17.378212", "end": "2023-01-24 00:57:23.892357", "failed_when_result": true, "item": {"base": "19.3.0.0.0", "category": "RU_Combo", "md5sum": "GAdowBq8IzvPAqD3wMnd/g==", "method": "opatch apply", "ocm": false, "patch_subdir": "/34411846", "patchfile": "p34449117_190000_Linux-x86-64.zip", "patchnum": "34449117", "prereq_check": true, "release": "19.17.0.0.221018", "upgrade": true}, "msg": "non-zero return code", "rc": 73, "start": "2023-01-24 00:56:06.514145", "stderr": "
...
Make failed to invoke \"/usr/bin/make -f ins_rdbms.mk javavm_refresh ORACLE_HOME=/u01/app/oracle/product/19.3.0/dbhome_1 OPATCH_SESSION=apply\"....'make: perl: Command not found\nmake: *** [ins_rdbms.mk:573: javavm_refresh] Error 127\n'\n\nThe following make actions have failed :\n\nRe-link fails on target \"javavm_refresh\"
```