### PR TITLE
Kill TFA process as part of cleanup

### DIFF
--- a/roles/brute-ora-cleanup/tasks/main.yml
+++ b/roles/brute-ora-cleanup/tasks/main.yml
@@ -71,6 +71,7 @@
     - orachkscheduler
     - OSWatcher
     - PROTOCOL=beq
+    - oracle.rat.tfa
     - '\\+ASM'
     - /grid/bin
     - /grid/jdk
@@ -99,6 +100,7 @@
     - orachkscheduler
     - OSWatcher
     - PROTOCOL=beq
+    - oracle.rat.tfa
     - '\\+ASM'
     - /grid/bin
     - /grid/jdk


### PR DESCRIPTION
In recent versions of Oracle 19c at least, Oracle TFA runs as root, so gets missed by the process kill.  Explicitly adding a snippet of the process name to make sure it gets cleaned up along with the rest of the install.

An example on a freshly cleaned-up server:

```
$ ps -ef | grep grid
root      144910       1  2 00:47 ?        00:00:39 /opt/oracle.ahf/jre/bin/java -server -Xms128m -Xmx256m -Djava.awt.headless=true -Ddisable.checkForUpdate=true -XX:HeapDumpPath=/u01/app/grid/oracle.ahf/data/toolkit-ol8/diag/tfa -XX:ParallelGCThreads=5 oracle.rat.tfa.TFAMain /opt/oracle.ahf/tfa
```