### PR TITLE
Fix partitioned filesystems and TFA in cleanup

### DIFF
--- a/roles/brute-ora-cleanup/tasks/main.yml
+++ b/roles/brute-ora-cleanup/tasks/main.yml
@@ -232,6 +232,15 @@
     state: absent
   with_items:
     - "{{ oracle_user_data_mounts }}"
+    
+- name: Remove magic strings from Oracle user data partitions
+  become: yes
+  become_user: root
+  command: "wipefs --all --force {{ item.blk_device }}1"
+  when: "'mapper' not in item.blk_device"
+  ignore_errors: true
+  with_items:
+    - "{{ oracle_user_data_mounts }}"
 
 - name: Remove magic strings from Oracle user data disks
   become: yes

--- a/roles/brute-ora-cleanup/tasks/main.yml
+++ b/roles/brute-ora-cleanup/tasks/main.yml
@@ -60,6 +60,16 @@
   become: yes
   become_user: root
   when: cluster_name is not defined
+  
+- name: Uninstall TFA service
+  command: "{{ grid_home }}/bin/tfactl uninstall -local -silent"
+  environment:
+    PATH: "{{ grid_home }}/perl/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+    PERL5LIB: "{{ grid_home }}/perl/lib"
+  register: uninstall_tfa
+  ignore_errors: yes
+  become: yes
+  become_user: root
 
 - name: Kill (SIGTERM) any remaining Oracle processes
   command: "pkill -f {{ item }}"


### PR DESCRIPTION
This change has two separate commits, bundled together for ease of application.

1. Shut down TFA service as part of cleanup
The TFA service, particularly in recent versions of 19c, is tightly integrated with the OS, with a systemd unit, an install in /opt, running as root, and other parts that our uninstall misses.  By holding open files in /u01, it can cause the unmount and thus disk cleanup to fail.

This change runs TFA's official uninstall script.  It takes about a minute or two to cleanly shut down TFA in my experience so does extend the runtime for the cleanup however.

2. Remove filesystem from partitioned disks
Most of our testing happens in `/dev/mapper` devices which are left unpartitioned by the toolkit.  However, for other devices, the toolkit partitions the disk.  This can create an issue on cleanup: the partition itself gets wiped but not the filesystem.  So when the partition is recreated, the filesystem reappears and can potentially cause issues on future `mkfs` runs.

This change adds an extra step, running mkfs on the partition itself, in addition to the block device.  The first run removes filesystem signatures, and the second run removes the partition table itself.

Sample output:  https://gist.github.com/mfielding/0d2d2031e243495deb05c09310ef7dff