### PR TITLE
Resolve NullPointerException for 19.3 OL8 install

### DIFF
--- a/roles/rac-db-setup/tasks/rac-db-install.yml
+++ b/roles/rac-db-setup/tasks/rac-db-install.yml
@@ -111,6 +111,18 @@
   become_user: "{{ oracle_user }}"
   tags: rac-db,update-opatch-db
 
+- name: rac-db-install | Patch OL8 CVU issue MOS note 2878100.1
+  become: yes
+  become_user: "{{ oracle_user }}"
+  lineinfile:
+    path: "{{ oracle_home }}/cv/admin/cvu_config"
+    regexp: "^CV_ASSUME_DISTID"
+    line: "CV_ASSUME_DISTID=OEL7.8"
+  when:
+    - ansible_distribution == 'OracleLinux'
+    - ansible_distribution_major_version >= 8
+    - oracle_ver_base == '19.3'
+
 - name: rac-db-install | Set installer command
   set_fact:
     installer_command: "{{ runinstaller_loc }}/runInstaller -silent -waitforcompletion -responseFile {{ install_unzip_path }}/db_install.rsp {{ rel_patch | default('') }} {{ prereq_option }}"

--- a/roles/rac-gi-setup/tasks/rac-gi-install.yml
+++ b/roles/rac-gi-setup/tasks/rac-gi-install.yml
@@ -94,6 +94,18 @@
     - "{{ osw_files }}"
   tags: rac-gi,sw-unzip
 
+- name: rac-gi-install | Patch OL8 CVU issue MOS note 2878100.1
+  become: yes
+  become_user: "{{ grid_user }}"
+  lineinfile:
+    path: "{{ install_unzip_path }}/cv/admin/cvu_config"
+    regexp: "^CV_ASSUME_DISTID"
+    line: "CV_ASSUME_DISTID=OEL7.8"
+  when:
+    - ansible_distribution == 'OracleLinux'
+    - ansible_distribution_major_version >= 8
+    - oracle_ver_base == '19.3'
+
 - name: rac-gi-install | Get symlinks for devices
   become: yes
   become_user: root


### PR DESCRIPTION
The cluster verification utility run in the grid install can error out with a NullPointerException with Oracle Linux 8 and early Oracle 19.3 software releases.  It occurs because the CVU bundled with early 19.3 releases pre-dates the availability of Oracle Linux 8, and doesn't take its configuration into account.  MOS note 2878100.1 expands on the issue a bit.


```
TASK [rac-gi-setup : rac-gi-install | Run installer] ***************************
fatal: [toolkit-ol8]: FAILED! => {"changed": true, "cmd": ["/u01/app/19.3.0/grid/gridSetup.sh", "-silent", "-responseFile", "/u01/app/19.3.0/grid/gridsetup.rsp", "-J-Doracle.install.mgmtDB=false", "-J-Doracle.install.mgmtDB.CDB=false", "-J-Doracle.install.crs.enableRemoteGIMR=false", "-ignorePrereqFailure"], "delta": "0:00:01.956342", "end": "2023-01-24 16:59:54.634864", "failed_when_result": true, "msg": "non-zero return code", "rc": 255, "start": "2023-01-24 16:59:52.678522", "stderr": "", "stderr_lines": [], "stdout": "Launching Oracle Grid Infrastructure Setup Wizard...\n\n[WARNING] [INS-08101] Unexpected error while executing the action at state: 'supportedOSCheck'\n   CAUSE: No additional information available.\n   ACTION: Contact Oracle Support Services or refer to the software manual.\n   SUMMARY:\n       - java.lang.NullPointerException\nMoved the install session logs to:\n /u01/app/oraInventory/logs/GridSetupActions2023-01-24_04-59-52PM", "stdout_lines": ["Launching Oracle Grid Infrastructure Setup Wizard...", "", "[WARNING] [INS-08101] Unexpected error while executing the action at state: 'supportedOSCheck'", "   CAUSE: No additional information available.", "   ACTION: Contact Oracle Support Services or refer to the software manual.", "   SUMMARY:", "       - java.lang.NullPointerException", "Moved the install session logs to:", " /u01/app/oraInventory/logs/GridSetupActions2023-01-24_04-59-52PM"]}
```

I like Martin Berger's fix in https://www.martinberger.com/2020/05/install-oracle-19c-rdbms-on-oracle-linux-8-avoid-warning-ins-08101-unexpected-error-while-executing-the-action-at-state-supportedoscheck/ : patching cvu_config itself to set the default there, avoiding complex conditional environment variable manipulation.

We apply the same change for GI and DB installs, as they both come from different installation media that each have their own copy of the CVU to patch.

The key to reproducing the issue it to install 19.3 with the `--no-patch` argument to use the base 19.3 install (which is affected)

Output snippet:

https://gist.github.com/mfielding/48b90a920088116a55cb9d308f86e647