### PR TITLE
Fix archivelog setting for single-node clusters

### DIFF
--- a/roles/db-adjustements/templates/archivelog_mode.sh.j2
+++ b/roles/db-adjustements/templates/archivelog_mode.sh.j2
@@ -25,6 +25,6 @@ select name, display_value from v\$system_parameter2 where name like 'db_recover
 order by 1,2;
 EOF
 
-{% if cluster_type == 'RAC' %}
+{% if if groups['dbasm'].length > 1 %}
 srvctl start db -d {{ db_name }}
 {% endif %}

--- a/roles/db-adjustements/templates/archivelog_mode.sh.j2
+++ b/roles/db-adjustements/templates/archivelog_mode.sh.j2
@@ -25,6 +25,6 @@ select name, display_value from v\$system_parameter2 where name like 'db_recover
 order by 1,2;
 EOF
 
-{% if if groups['dbasm'].length > 1 %}
+{% if groups['dbasm'] | length > 1 %}
 srvctl start db -d {{ db_name }}
 {% endif %}


### PR DESCRIPTION
`archivelog_mode.sh` shuts down the database cluster using srvctl, restarts it on the local node using sqlplus, and then, if RAC, attempts to start it again using srvctl.

This command works for 2-node clusters, since the `srvctl start` command has a second node to start.  But with a single-node cluster, it errors out because the database is already running.  The error is ignored so the install doesn't fail, but the error is unsightly.

Sample error:

```
TASK [db-adjustements : Run database adjustment scripts on target server] ******
failed: [toolkit-ol8] (item=archivelog_mode.sh) => {"ansible_loop_var": "item", "changed": true, "cmd": "/u01/oracle_install/archivelog_mode.sh", "delta": "0:01:29.925785", "end": "2023-01-24 19:06:11.420627", "item": "archivelog_mode.sh", "msg": "non-zero return code", "rc": 2, "start": "2023-01-24 19:04:41.494842", "stderr": "", "stderr_lines": [], "stdout": "ORACLE_SID = [oracle] ? The Oracle base has been set to /u01/app/oracle\nORACLE instance started.\n\nTotal System Global Area 3.0467E+10 bytes\nFixed Size\t\t   12453248 bytes\nVariable Size\t\t 3556769792 bytes\nDatabase Buffers\t 2.6844E+10 bytes\nRedo Buffers\t\t   54652928 bytes\nDatabase mounted.\n\nDatabase altered.\n\n\nDatabase altered.\n\nDatabase log mode\t       Archive Mode\nAutomatic archival\t       Enabled\nArchive destination\t       USE_DB_RECOVERY_FILE_DEST\nOldest online log sequence     12\nNext log sequence to archive   14\nCurrent log sequence\t       14\n\nDatabase altered.\n\n\nSTATUS                           FILENAME\n-------------------------------- ----------------------------------------------------------------\nENABLED                          +DATA/ORCL/CHANGETRACKING/ctf.269.1126983969\n\n\nNAME                             DISPLAY_VALUE\n-------------------------------- ----------------------------------------------------------------\ndb_recovery_file_dest            +RECO\ndb_recovery_file_dest_size       7356M\n\nPRCC-1014 : orcl was already running\nPRCR-1004 : Resource ora.orcl.db is already running\nPRCR-1079 : Failed to start resource ora.orcl.db\nCRS-5702: Resource 'ora.orcl.db' is already running on 'toolkit-ol8'", "stdout_lines": ["ORACLE_SID = [oracle] ? The Oracle base has been set to /u01/app/oracle", "ORACLE instance started.", "", "Total System Global Area 3.0467E+10 bytes", "Fixed Size\t\t   12453248 bytes", "Variable Size\t\t 3556769792 bytes", "Database Buffers\t 2.6844E+10 bytes", "Redo Buffers\t\t   54652928 bytes", "Database mounted.", "", "Database altered.", "", "", "Database altered.", "", "Database log mode\t       Archive Mode", "Automatic archival\t       Enabled", "Archive destination\t       USE_DB_RECOVERY_FILE_DEST", "Oldest online log sequence     12", "Next log sequence to archive   14", "Current log sequence\t       14", "", "Database altered.", "", "", "STATUS                           FILENAME", "-------------------------------- ----------------------------------------------------------------", "ENABLED                          +DATA/ORCL/CHANGETRACKING/ctf.269.1126983969", "", "", "NAME                             DISPLAY_VALUE", "-------------------------------- ----------------------------------------------------------------", "db_recovery_file_dest            +RECO", "db_recovery_file_dest_size       7356M", "", "PRCC-1014 : orcl was already running", "PRCR-1004 : Resource ora.orcl.db is already running", "PRCR-1079 : Failed to start resource ora.orcl.db", "CRS-5702: Resource 'ora.orcl.db' is already running on 'toolkit-ol8'"]}
changed: [toolkit-ol8] => (item=db_modifications.sh)
...ignoring
```

This change updates the logic to, instead of looking for a RAC database, to count the number of nodes, and start via `srvctl` if there is more than one node.