### PR TITLE
Don't validate opatch in a no-patch install

### DIFF
--- a/roles/check-swlib/tasks/main.yml
+++ b/roles/check-swlib/tasks/main.yml
@@ -62,7 +62,7 @@
   ignore_errors: true
   with_items:
     - "{{ opatch_patches }}"
-  when: item.release == oracle_ver
+  when: item.release == oracle_ver and oracle_rel != "base"
   register: opatch_repo_files
 
 - name: check-swlib | Report gsutil failures (base)


### PR DESCRIPTION
The `--no-patch` argument to `check-swlib.sh` and `install-oracle.sh` installs the base Oracle release without applying patches.  This argument ends up setting `oracle_rel` to `base`.  If not applying patches, `opatch` is unnecessary.  And without access to My Oracle Support, there's no way to download it.

This change simply ships the opatch check if `oracle_rel` is set to `base`

Testcase: https://gist.github.com/mfielding/2a3279abcc560e3e29180c92f09b7d22

```
$ ./check-swlib.sh --ora-swlib-bucket gs://mfielding-oracle-software --no-patch
Command used:
./check-swlib.sh --ora-swlib-bucket gs://mfielding-oracle-software --no-patch

Running with parameters from command line or environment variables:

ORA_EDITION=EE
ORA_RELEASE=base
ORA_SWLIB_BUCKET=gs://mfielding-oracle-software
ORA_VERSION=19.3.0.0.0

Found Ansible: ansible-playbook is /usr/bin/ansible-playbook

Running Ansible playbook: ansible-playbook -i localhost,   check-swlib.yml

PLAY [Set correct RDBMS release] *********************************************************************************************************************************************************

TASK [Verify that Ansible on control node meets the version requirements] ****************************************************************************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "Ansible version is 2.10.8, continuing"
}

TASK [common : populate-vars | Show resolved release] ************************************************************************************************************************************
ok: [localhost] => {
    "oracle_rel": "base"
}

PLAY [Check swlib] ***********************************************************************************************************************************************************************

TASK [check-swlib : check-swlib | Validate base software release] ************************************************************************************************************************
ok: [localhost] => (item={'name': '19c_gi', 'version': '19.3.0.0.0', 'files': ['V982068-01.zip'], 'sha256sum': ['D668002664D9399CF61EB03C0D1E3687121FC890B1DDD50B35DCBE13C5307D2E'], 'md5sum': ['t8TGb4AfktFPqg15HM2nIQ==']})
ok: [localhost] => (item={'name': '19c_base', 'version': '19.3.0.0.0', 'edition': ['EE', 'SE2'], 'files': ['V982063-01.zip'], 'sha256sum': ['BA8329C757133DA313ED3B6D7F86C5AC42CD9970A28BF2E6233F3235233AA8D8'], 'md5sum': ['GFi9DSgcYPTdq9h7HCFKTw==']})

PLAY RECAP *******************************************************************************************************************************************************************************
localhost                  : ok=3    changed=0    unreachable=0    failed=0    skipped=8    rescued=0    ignored=0
```
