### PR TITLE
Fix data types in version comparison

### DIFF
--- a/roles/rac-db-setup/tasks/rac-db-install.yml
+++ b/roles/rac-db-setup/tasks/rac-db-install.yml
@@ -120,7 +120,7 @@
     line: "CV_ASSUME_DISTID=OEL7.8"
   when:
     - ansible_distribution == 'OracleLinux'
-    - ansible_distribution_major_version >= 8
+    - ansible_distribution_major_version >= '8'
     - oracle_ver_base == '19.3'
 
 - name: rac-db-install | Set installer command

--- a/roles/rac-gi-setup/tasks/rac-gi-install.yml
+++ b/roles/rac-gi-setup/tasks/rac-gi-install.yml
@@ -103,7 +103,7 @@
     line: "CV_ASSUME_DISTID=OEL7.8"
   when:
     - ansible_distribution == 'OracleLinux'
-    - ansible_distribution_major_version >= 8
+    - ansible_distribution_major_version >= '8'
     - oracle_ver_base == '19.3'
 
 - name: rac-gi-install | Get symlinks for devices


### PR DESCRIPTION
The ansible fact `ansible_distribution_major_version` is actually a string, not a number.  The implicit conversion succeeds in CentOS 7, but with Debian 11 (which has Ansible 2.10 rather than 2.9), I get an error:

```
TASK [rac-gi-setup : rac-gi-install | Patch OL8 CVU issue MOS note 2878100.1] ***
fatal: [database-vm]: FAILED! => {"msg": "The conditional check 'ansible_distribution_major_version >= 8' failed. The error was: Unexpected templating type error occurred on ({% if ansible_distribution_major_version >= 8 %} True {% else %} False {% endif %}): '>=' not supported between instances of 'AnsibleUnsafeText' and 'int'\n\nThe error appears to be in '/home/mfielding_google_com/bms-toolkit/roles/rac-gi-setup/tasks/rac-gi-install.yml': line 97, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: rac-gi-install | Patch OL8 CVU issue MOS note 2878100.1\n  ^ here\n"}
```

Quoting the comparator to consider it as a string too.  Making the same change to the database check as well.

After the change:

```
TASK [rac-gi-setup : rac-gi-install | Patch OL8 CVU issue MOS note 2878100.1] ***
changed: [database-vm]
...
