### PR TITLE
Minor fixes to the user guide documentation

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -247,8 +247,7 @@ install Ansible with `sudo apt-get install ansible`. Your installation command
 might be different. You can verify your version of Ansible with ansible
 `--version`.
 
-You can use the [Google Cloud
-Shell]([https://cloud.google.com/shell](https://cloud.google.com/shell)) as your
+You can use the [Google Cloud Shell](https://cloud.google.com/shell) as your
 control node. Cloud Shell provides command-line access to a virtual machine
 instance in a terminal window that opens in the web console. The latest version
 of Cloud SDK is installed for you.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -265,7 +265,7 @@ certified for Oracle Database. The toolkit currently supports the following
 certified OS versions:
 
 - Red Hat Enterprise Linux (RHEL) 7 and 8 (versions 7.3 and up).
-- Oracle Enterprise Linux (OEL) 7 and 8 (versions 7.3 and up).
+- Oracle Linux (OL) 7 and 8 (versions 7.3 and up).
 
 For more information about Oracle-supported platforms see the Oracle
 certification matrix in the "My Oracle Support" (MOS) site (sign in required):


### PR DESCRIPTION
This pull request includes the following:

1. Fix for a broken link to Google Cloud Shell
2. Correct of naming of Oracle [Enterprise] Linux - The "Enterprise" was dropped by Oracle for release 5.5 (links in commit message)