### PR TITLE
Resolve a warning message about 'item' variable

### DIFF
--- a/roles/common/tasks/populate-asm-disks.yml
+++ b/roles/common/tasks/populate-asm-disks.yml
@@ -8,7 +8,7 @@
 
 - name: Resolve the symlinks
   ansible.builtin.shell:
-    cmd: "realpath {{ item  }}"
+    cmd: "realpath {{ item }}"
   loop: "{{ asm_disks | map(attribute='disks') | flatten | map(attribute='blk_device') }}"
   register: realpath_output
   tags: populate-asm-disks
@@ -38,5 +38,5 @@
   set_fact:
     asm_disks: "{{asm_disks_with_partitions}}"
   when:
-  - asm_disks_with_partitions is defined
+    - asm_disks_with_partitions is defined
   tags: populate-asm-disks

--- a/roles/ora-host/tasks/main.yml
+++ b/roles/ora-host/tasks/main.yml
@@ -285,11 +285,13 @@
 - include_role:
     name: common
     tasks_from: populate-asm-disks.yml
-  when: "'mapper' not in item.1.blk_device"
+  when: "'mapper' not in outer_item.1.blk_device"
   run_once: true
   with_subelements:
     - "{{ asm_disks }}"
     - disks
+  loop_control:
+    loop_var: outer_item
 
 - name: (debug) asm disk configuration
   debug:


### PR DESCRIPTION
This PR fixes a warning about the repeated use of the "item" variable. It appears the tasks from populate-asm-disks.yml are part of a loop with the loop variable named 'item,' and the included task also contains a loop with the default variable name 'item',  which causes the warning. The solution is to specify the name of the variable for the outer loop using loop_var with loop_control.