### PR TITLE
Add metadata for January 2024 patches

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -350,6 +350,12 @@ Support")</th>
 <tr>
 <td></td>
 <td>Patch - MOS</TD>
+<TD>COMBO OF OJVM RU COMPONENT 19.22.0.0.240116 + GI RU 19.22.0.0.240116</td>
+<td>p36031453_190000_Linux-x86-64.zip</td>
+</tr>
+<tr>
+<td></td>
+<td>Patch - MOS</TD>
 <TD>COMBO OF OJVM RU COMPONENT 19.21.0.0.231017 + GI RU 19.21.0.0.231017</td>
 <td>p35742441_190000_Linux-x86-64.zip</td>
 </tr>

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -312,6 +312,8 @@ gi_patches:
   - { category: "RU", base: "19.3.0.0.0", release: "19.19.0.0.230418", patchnum: "35058172", patchfile: "p35058172_190000_Linux-x86-64.zip", patch_subdir: "/35037840", prereq_check: FALSE, method: "opatchauto apply", ocm: FALSE, upgrade: FALSE, md5sum: "ZUIxTPD1d4mtalg1FuiYWA==" }
   - { category: "RU", base: "19.3.0.0.0", release: "19.20.0.0.230718", patchnum: "35370167", patchfile: "p35370167_190000_Linux-x86-64.zip", patch_subdir: "/35319490", prereq_check: FALSE, method: "opatchauto apply", ocm: FALSE, upgrade: FALSE, md5sum: "921xb/KsOPOQy11PgDKVkg==" }
   - { category: "RU", base: "19.3.0.0.0", release: "19.21.0.0.231017", patchnum: "35742441", patchfile: "p35742441_190000_Linux-x86-64.zip", patch_subdir: "/35642822", prereq_check: FALSE, method: "opatchauto apply", ocm: FALSE, upgrade: FALSE, md5sum: "XCHpxqMlJ0/4dTUeMYNcSg==" }
+  - { category: "RU", base: "19.3.0.0.0", release: "19.22.0.0.240116", patchnum: "36031453", patchfile: "p36031453_190000_Linux-x86-64.zip", patch_subdir: "/35940989", prereq_check: FALSE, method: "opatchauto a
+pply", ocm: FALSE, upgrade: FALSE, md5sum: "HEUyMq/Zdugnxn76ebihgA==" }
 
 rdbms_patches:
 # 11.2.0.4 OJVM packages from Combo
@@ -375,3 +377,5 @@ rdbms_patches:
   - { category: "RU_Combo", base: "19.3.0.0.0", release: "19.19.0.0.230418", patchnum: "35058172", patchfile: "p35058172_190000_Linux-x86-64.zip", patch_subdir: "/35050341", prereq_check: TRUE, method: "opatch apply", ocm: FALSE, upgrade: TRUE, md5sum: "ZUIxTPD1d4mtalg1FuiYWA==" }
   - { category: "RU_Combo", base: "19.3.0.0.0", release: "19.20.0.0.230718", patchnum: "35370167", patchfile: "p35370167_190000_Linux-x86-64.zip", patch_subdir: "/35354406", prereq_check: TRUE, method: "opatch apply", ocm: FALSE, upgrade: TRUE, md5sum: "921xb/KsOPOQy11PgDKVkg==" }
   - { category: "RU_Combo", base: "19.3.0.0.0", release: "19.21.0.0.231017", patchnum: "35742441", patchfile: "p35742441_190000_Linux-x86-64.zip", patch_subdir: "/35648110", prereq_check: TRUE, method: "opatch apply", ocm: FALSE, upgrade: TRUE, md5sum: "XCHpxqMlJ0/4dTUeMYNcSg==" }
+  - { category: "RU_Combo", base: "19.3.0.0.0", release: "19.22.0.0.240116", patchnum: "36031453", patchfile: "p36031453_190000_Linux-x86-64.zip", patch_subdir: "/35926646", prereq_check: TRUE, method: "opatch
+apply", ocm: FALSE, upgrade: TRUE, md5sum: "HEUyMq/Zdugnxn76ebihgA==" }


### PR DESCRIPTION
Source doc:

https://support.oracle.com/epmos/faces/SearchDocDisplay?_adf.ctrl-state=lxqk64d2j_214&_afrLoop=397795212427799

Output from bms-toolkit run on a GCE instance using 19.22.0.0.240116 release: https://gist.github.com/alex-basinov/f895aa6d4dd82a8b83cae981a81101c5