### PR TITLE
Don't update asm_disks fact with partition IDs for /dev/mapper/<WWID> disks

### DIFF
--- a/roles/rac-gi-setup/tasks/rac-gi-install.yml
+++ b/roles/rac-gi-setup/tasks/rac-gi-install.yml
@@ -109,6 +109,13 @@
 - include_role:
     name: common
     tasks_from: populate-asm-disks.yml
+  when: "'mapper' not in outer_item.1.blk_device"
+  run_once: true
+  with_subelements:
+    - "{{ asm_disks }}"
+    - disks
+  loop_control:
+    loop_var: outer_item
 
 - name: rac-gi-install | Get symlinks for devices
   become: yes


### PR DESCRIPTION
Output from running install-oracle.sh script: https://gist.github.com/alex-basinov/5d82c5f869f043551ad9be50856e6e97
