### PR TITLE
Add support for RHEL9 and OL9

### DIFF
--- a/roles/ora-host/defaults/main.yml
+++ b/roles/ora-host/defaults/main.yml
@@ -16,7 +16,7 @@
 install_os_packages: true
 disable_firewall: false
 disable_selinux: true
-firewall_service: "{% if ansible_distribution_major_version|int==6%}iptables{%elif ansible_distribution_major_version|int==7 %}firewalld{% else %}0{% endif %}"
+firewall_service: "{% if ansible_distribution_major_version|int==6%}iptables{%elif ansible_distribution_major_version|int>=7 %}firewalld{% else %}0{% endif %}"
 
 oracle_required_rpms:
   - bc
@@ -127,6 +127,57 @@ oracle_required_rpms_el8:
   - libnsl2
   - libnsl2.i686  
 
+oracle_required_rpms_el9:
+  - bc
+  - binutils
+  - cpp
+  - gcc
+  - gcc-c++
+  - glibc-devel
+  - glibc-headers
+  - gssproxy
+  - kernel-headers
+  - keyutils
+  - ksh
+  - libaio-devel
+  - libbasicobjects
+  - libcollection
+  - libdmx
+  - libevent
+  - libICE
+  - libini_config
+  - libmpc
+  - libnfsidmap
+  - libpath_utils
+  - libref_array
+  - libSM
+  - libstdc++-devel
+  - libtirpc
+  - libXi
+  - libXinerama
+  - libXmu
+  - libXrandr
+  - libXrender
+  - libXt
+  - libXtst
+  - libXv
+  - libXxf86dga
+  - libXxf86vm
+  - make
+  - mpfr
+  - nfs-utils
+  - psmisc
+  - quota
+  - quota-nls
+  - rpcbind
+  - smartmontools
+  - sysstat
+  - xorg-x11-utils
+  - xorg-x11-xauth
+  - libnsl
+  - libnsl.i686
+  - libnsl2
+  - libnsl2.i686  
 
 sysctl_entries:
   - { name: "fs.aio-max-nr", value: "1048576" }

--- a/roles/ora-host/defaults/main.yml
+++ b/roles/ora-host/defaults/main.yml
@@ -153,6 +153,7 @@ oracle_required_rpms_el9:
   - libSM
   - libstdc++-devel
   - libtirpc
+  - libxcrypt-compat
   - libXi
   - libXinerama
   - libXmu
@@ -166,6 +167,7 @@ oracle_required_rpms_el9:
   - make
   - mpfr
   - nfs-utils
+  - policycoreutils-python-utils
   - psmisc
   - quota
   - quota-nls

--- a/roles/ora-host/tasks/main.yml
+++ b/roles/ora-host/tasks/main.yml
@@ -145,7 +145,7 @@
     - install_os_packages|bool
     - ansible_distribution == 'OracleLinux'
     - ansible_distribution_major_version == '9'
-     oraclelinux_repo_oel9.stat.exists|bool
+    - oraclelinux_repo_oel9.stat.exists|bool
   tags: os-packages
 
 - name: Install Oracle required packages (rhui config)

--- a/roles/ora-host/tasks/main.yml
+++ b/roles/ora-host/tasks/main.yml
@@ -87,6 +87,13 @@
   when:
     - install_os_packages|bool and ansible_distribution == 'OracleLinux'
 
+- name: Stat OL9 repo
+  stat:
+    path: /etc/yum.repos.d/oracle-linux-ol9.repo
+  register: oraclelinux_repo_oel9
+  when:
+    - install_os_packages|bool and ansible_distribution == 'OracleLinux'
+
 - name: Install Oracle required packages (base/non-rhui config) for OEL7
   yum:
     name: "{{ oracle_required_rpms }}"
@@ -107,6 +114,18 @@
     - redhat_repo.stat.exists|bool or rh_cloud_repo.stat.exists|bool
   tags: os-packages
 
+- name: Install Oracle required packages (base/non-rhui config) for RHEL9
+  yum:
+    name: "{{ oracle_required_rpms_el9 }}"
+    state: present
+    lock_timeout: 180
+  when:
+    - install_os_packages|bool
+    - ansible_distribution == 'RedHat'
+    - ansible_distribution_major_version == '9'
+    - rh_cloud_repo.stat.exists|bool
+  tags: os-packages
+
 - name: Install Oracle required packages (base/non-rhui config) for OEL8
   yum:
     name: "{{ oracle_required_rpms_el8 }}"
@@ -115,6 +134,18 @@
   when:
     - install_os_packages|bool and ansible_distribution == 'OracleLinux' and ansible_distribution_major_version == '8'
     - oraclelinux_repo_oel8.stat.exists|bool
+  tags: os-packages
+
+- name: Install Oracle required packages (base/non-rhui config) for OEL9
+  yum:
+    name: "{{ oracle_required_rpms_el9 }}"
+    state: present
+    lock_timeout: 180
+  when:
+    - install_os_packages|bool
+    - ansible_distribution == 'OracleLinux'
+    - ansible_distribution_major_version == '9'
+     oraclelinux_repo_oel9.stat.exists|bool
   tags: os-packages
 
 - name: Install Oracle required packages (rhui config)
@@ -177,6 +208,31 @@
   with_items:
     - "{{ sysctl_entries }}"
   tags: sysctl
+
+- name: Get the ID of the oinstall group
+  shell:
+    cmd: "getent group oinstall | cut -d: -f3"
+  register: oinstall_group_id
+  changed_when: false
+  when:
+    - ansible_distribution == 'RedHat'
+    - ansible_distribution_major_version == '9'
+
+
+# Setting vm.hugetlb_shm_group to the ID of the "oinstall" group to allow its members to create 
+# SysV shared memory segment using hugetlb page. 
+# By default only the root user has permissions to create shared memory segments.
+# This is needed to prevent the occurrence of "ORA-27125: unable to create shared memory segment" error.
+- name: Set hugetlb_shm_group to the ID of the oinstall group
+  sysctl:
+    name: vm.hugetlb_shm_group
+    value: "{{ oinstall_group_id.stdout }}"
+    state: present
+    reload: true
+  become: true
+  when:
+    - ansible_distribution == 'RedHat'
+    - ansible_distribution_major_version == '9'
 
 - name: Adjust kernel limits for users
   pam_limits:


### PR DESCRIPTION
b/308784280

This PR adds support for RHEL9 and OL9 OSes.

The changes included are as follows:

1. Created a copy of the oracle_required_rpms_el8 list that excludes RPM packages that are no longer available in RHEL9.
2. Set vm.hugetlb_shm_group to the "oinstall" group's ID, enabling its members to create shared memory segments and mitigating the occurrence of "ORA-27125: unable to create shared memory segment" error during the database creation.