### PR TITLE
Referene the GID of the 'oinstall' group using Jinja2 expression

### DIFF
--- a/roles/ora-host/tasks/main.yml
+++ b/roles/ora-host/tasks/main.yml
@@ -209,16 +209,6 @@
     - "{{ sysctl_entries }}"
   tags: sysctl
 
-- name: Get the ID of the oinstall group
-  shell:
-    cmd: "getent group oinstall | cut -d: -f3"
-  register: oinstall_group_id
-  changed_when: false
-  when:
-    - ansible_distribution == 'RedHat'
-    - ansible_distribution_major_version == '9'
-
-
 # Setting vm.hugetlb_shm_group to the ID of the "oinstall" group to allow its members to create 
 # SysV shared memory segment using hugetlb page. 
 # By default only the root user has permissions to create shared memory segments.
@@ -226,7 +216,7 @@
 - name: Set hugetlb_shm_group to the ID of the oinstall group
   sysctl:
     name: vm.hugetlb_shm_group
-    value: "{{ oinstall_group_id.stdout }}"
+    value: "{{ oracle_groups | selectattr('group', 'match', 'oinstall') | map(attribute='gid') | first }}"
     state: present
     reload: true
   become: true


### PR DESCRIPTION
As per suggestion from [PR #163](https://github.com/google/bms-toolkit/pull/163 ), reference the GID of the 'oinstall' group using Jinja2 expression