### PR TITLE
Handle ASM diskgroups with multiple disks

### DIFF
--- a/install-oracle.sh
+++ b/install-oracle.sh
@@ -240,7 +240,7 @@ GETOPT_OPTIONAL="$GETOPT_OPTIONAL,backup-redundancy:,archive-redundancy:,archive
 GETOPT_OPTIONAL="$GETOPT_OPTIONAL,backup-start-hour:,backup-start-min:,archive-backup-min:,backup-script-location:,backup-log-location:"
 GETOPT_OPTIONAL="$GETOPT_OPTIONAL,ora-swlib-type:,ora-swlib-path:,ora-swlib-credentials:,instance-ip-addr:,primary-ip-addr:,instance-ssh-user:"
 GETOPT_OPTIONAL="$GETOPT_OPTIONAL,instance-ssh-key:,instance-hostname:,ntp-pref:,inventory-file:,compatible-rdbms:,instance-ssh-extra-args:"
-GETOPT_OPTIONAL="$GETOPT_OPTIONAL,help,validate,check-instance,prep-host,install-sw,config-db,debug,allow-install-on-vm,skip-database-config"
+GETOPT_OPTIONAL="$GETOPT_OPTIONAL,help,validate,check-instance,prep-host,install-sw,config-db,debug,allow-install-on-vm,skip-database-config,swap-blk-device:"
 GETOPT_LONG="$GETOPT_MANDATORY,$GETOPT_OPTIONAL"
 GETOPT_SHORT="h"
 
@@ -870,6 +870,7 @@ export ORA_VERSION
 export ORA_RELEASE
 export PB_LIST
 export PRIMARY_IP_ADDR
+export SWAP_BLK_DEVICE
 
 echo -e "Running with parameters from command line or environment variables:\n"
 set | egrep '^(ORA_|BACKUP_|ARCHIVE_|INSTANCE_|PB_|ANSIBLE_|CLUSTER|PRIMARY)' | grep -v '_PARAM='

--- a/roles/base-provision/tasks/swap.yml
+++ b/roles/base-provision/tasks/swap.yml
@@ -20,26 +20,42 @@
     state: present
   become: true
   register: swapfile_register_create
+  when: "'mapper' not in swap_blk_device"
+  # Logical volumes managed by LVM do not require 
+  # partitioning like traditional block devices because they are already abstracted 
+  # volumes that can be resized or moved without repartitioning the physical disks. 
 
 - include_role:
     name: common
     tasks_from: populate-swap-partition-id.yml
 
-- name: swap | Initialize swap file
+- name: swap | Initialize swap on standard partition
   command: mkswap -f {{ swap_partition_id }}
   become: true
   when: 
     - swapfile_register_create is changed
     - swap_partition_id is defined
+    - "'mapper' not in swap_blk_device"
 
-- name: swap | Enable swap file
+- name: swap | Initialize swap on LVM logical volume 
+  command: mkswap -f {{ swap_blk_device }}
+  become: true
+  when: "'mapper' in swap_blk_device"
+
+- name: swap | Enable swap on standard partition
   command: swapon {{ swap_partition_id }}
   become: true
   when: 
     - swapfile_register_create is changed
     - swap_partition_id is defined
+    - "'mapper' not in swap_blk_device"
 
-- name: swap | Manage swap file in /etc/fstab
+- name: swap | Enable swap on LVM logical volume 
+  command: swapon {{ swap_blk_device }}
+  become: true
+  when: "'mapper' in swap_blk_device"
+
+- name: swap | Add non-LVM swap entry to /etc/fstab
   mount:
     src: "{{ swap_partition_id }}"
     name: "none"
@@ -51,3 +67,16 @@
   become: true
   when:
     - swap_partition_id is defined
+    - "'mapper' not in swap_blk_device"
+
+- name: swap | Add LVM swap entry to /etc/fstab
+  mount:
+    src: "{{ swap_blk_device }}"
+    name: "none"
+    fstype: "swap"
+    opts: "sw,nofail"
+    dump: "0"
+    passno: "0"
+    state: "present"
+  become: true
+  when: "'mapper' in swap_blk_device"

--- a/roles/common/tasks/populate-asm-disks.yml
+++ b/roles/common/tasks/populate-asm-disks.yml
@@ -6,37 +6,57 @@
       - devices
   tags: populate-asm-disks
 
-- name: Resolve the symlinks
-  ansible.builtin.shell:
-    cmd: "realpath {{ item }}"
-  loop: "{{ asm_disks | map(attribute='disks') | flatten | map(attribute='blk_device') }}"
-  register: realpath_output
+- name: Determine real paths of block devices
+  ansible.builtin.shell: "readlink -f {{ item.1.blk_device }}"
+  with_subelements:
+   - "{{ asm_disks }}"
+   - disks
+  register: real_paths
+  changed_when: false
   tags: populate-asm-disks
 
-- name: Create a copy of the asm_disks with the blk_device set to the canonical path
+    
+- name: Update asm_disks with real paths
   set_fact:
-    asm_disks_normalized: "{{ asm_disks_normalized | default([]) + [item.1 | combine({'disks': item.1.disks | map('combine', {'blk_device': item.0.stdout}) | list })] }}"
-  with_together:
-    - "{{ realpath_output.results }}"
-    - "{{ asm_disks }}"
-  when: item.0.rc == 0 and item.1 is not none
-  tags: populate-asm-disks
-
-- name: Update asm_disks with partition IDs
-  set_fact:
-    asm_disks_with_partitions: "{{ asm_disks_with_partitions | default([]) + [{'diskgroup': item.diskgroup, 'disks': item.disks | map('combine', {'first_partition_id': first_partition_id}) | list}] }}"
-  with_items: "{{ asm_disks_normalized }}"
+    asm_disks_normalized: "{{ asm_disks_updated | from_yaml }}"
   vars:
-    first_partition_id: "{{'/dev/' + ansible_facts.devices[item.disks | map(attribute='blk_device') | join() | basename ].partitions.keys() | first }}"
-  loop_control:
-    label: "{{ item.diskgroup }}"
-  when:
-    - asm_disks_normalized is defined
+    asm_disks_updated: >
+      {% set disks = asm_disks | json_query('[].{diskgroup: diskgroup, disks: disks}') %}
+      {% for disk_group in disks %}
+        {% for disk in disk_group.disks %}
+          {% set real_path = real_paths.results | selectattr('item.1.blk_device', 'equalto', disk.blk_device) | map(attribute='stdout') | list %}
+          {% if real_path %}
+            {% set _ = disk.update({'real_path': real_path | first}) %}
+          {% endif %}
+        {% endfor %}
+      {% endfor %}
+      {{ disks }}
+
+
+- name: Add partition IDs to asm_disks
+  set_fact:
+    asm_disks: "{{ asm_disks_partitions | from_yaml }}"
+  vars:
+    asm_disks_partitions: >
+      {% set updated_disks = [] %}
+      {% for disk_group in asm_disks_normalized %}
+        {% set updated_group_disks = [] %}
+        {% for disk in disk_group.disks %}
+          {% set real_device = disk.real_path | regex_replace('^/dev/', '') %}
+          {% set device_facts = ansible_facts.devices[real_device] if real_device in ansible_facts.devices else {} %}
+          {% set partitions = device_facts.partitions if device_facts and 'partitions' in device_facts else {} %}
+          {% if partitions %}
+            {% set first_partition_key = partitions.keys() | list | sort | first %}
+            {% set first_partition = '/dev/' + first_partition_key %}
+          {% else %}
+            {% set first_partition = 'No partition' %}
+          {% endif %}
+          {% set disk_with_partition = disk | combine({'first_partition_id': first_partition}) %}
+          {% set _ = updated_group_disks.append(disk_with_partition) %}
+        {% endfor %}
+        {% set updated_group = {'diskgroup': disk_group.diskgroup, 'disks': updated_group_disks} %}
+        {% set _ = updated_disks.append(updated_group) %}
+      {% endfor %}
+      {{ updated_disks }}
   tags: populate-asm-disks
 
-- name: Update asm_disks
-  set_fact:
-    asm_disks: "{{asm_disks_with_partitions}}"
-  when:
-    - asm_disks_with_partitions is defined
-  tags: populate-asm-disks

--- a/roles/common/tasks/populate-asm-disks.yml
+++ b/roles/common/tasks/populate-asm-disks.yml
@@ -1,62 +1,43 @@
-- name: Collect new disk facts
-  setup:
-    gather_subset:
-      - '!all'
-      - '!any'
-      - devices
+- name: Resolve blk_device paths to first partition paths if they exist
+  ansible.builtin.shell: >
+    set -o pipefail;
+    case "{{ item.blk_device }}" in
+      /dev/disk/by-id/*)
+        part_path="{{ item.blk_device }}"-part1;
+        ;;
+      /dev/mapper/*)
+        part_path="{{ item.blk_device }}"p1;
+        ;;
+      /dev/*)
+        by_id_link=$(find /dev/disk/by-id/ -type l -exec sh -c 'echo $1 $(readlink -f $1)' _ {} \; | awk -v dev="{{ item.blk_device }}" '$2==dev {print $1}' | grep -vE '/dev/disk/by-id/(nvme-|scsi-|wwn-)' | head -n 1);
+        part_path="${by_id_link}"-part1;
+        ;;
+    esac;
+    if [[ -e "$part_path" ]]; then
+      echo "$part_path"
+    else
+      echo ""
+    fi
+  loop: "{{ asm_disks | json_query('[].disks[]') }}"
+  register: disk_paths
   tags: populate-asm-disks
 
-- name: Determine real paths of block devices
-  ansible.builtin.shell: "readlink -f {{ item.1.blk_device }}"
-  with_subelements:
-   - "{{ asm_disks }}"
-   - disks
-  register: real_paths
-  changed_when: false
-  tags: populate-asm-disks
 
-    
-- name: Update asm_disks with real paths
+- name: Update asm_disks with partition paths
   set_fact:
-    asm_disks_normalized: "{{ asm_disks_updated | from_yaml }}"
+    asm_disks: "{{ asm_disks_updated | from_yaml }}"
   vars:
     asm_disks_updated: >
-      {% set disks = asm_disks | json_query('[].{diskgroup: diskgroup, disks: disks}') %}
-      {% for disk_group in disks %}
+      {% set new_disks = [] %}
+      {% for disk_group in asm_disks %}
+        {% set new_group_disks = [] %}
         {% for disk in disk_group.disks %}
-          {% set real_path = real_paths.results | selectattr('item.1.blk_device', 'equalto', disk.blk_device) | map(attribute='stdout') | list %}
-          {% if real_path %}
-            {% set _ = disk.update({'real_path': real_path | first}) %}
-          {% endif %}
+          {% set output = disk_paths.results | selectattr('item.blk_device', 'equalto', disk.blk_device) | map(attribute='stdout') | first %}
+          {% set new_disk = disk | combine({'first_partition_id': output}) %}
+          {% set _ = new_group_disks.append(new_disk) %}
         {% endfor %}
+        {% set new_disk_group = {'diskgroup': disk_group.diskgroup, 'disks': new_group_disks} %}
+        {% set _ = new_disks.append(new_disk_group) %}
       {% endfor %}
-      {{ disks }}
-
-
-- name: Add partition IDs to asm_disks
-  set_fact:
-    asm_disks: "{{ asm_disks_partitions | from_yaml }}"
-  vars:
-    asm_disks_partitions: >
-      {% set updated_disks = [] %}
-      {% for disk_group in asm_disks_normalized %}
-        {% set updated_group_disks = [] %}
-        {% for disk in disk_group.disks %}
-          {% set real_device = disk.real_path | regex_replace('^/dev/', '') %}
-          {% set device_facts = ansible_facts.devices[real_device] if real_device in ansible_facts.devices else {} %}
-          {% set partitions = device_facts.partitions if device_facts and 'partitions' in device_facts else {} %}
-          {% if partitions %}
-            {% set first_partition_key = partitions.keys() | list | sort | first %}
-            {% set first_partition = '/dev/' + first_partition_key %}
-          {% else %}
-            {% set first_partition = 'No partition' %}
-          {% endif %}
-          {% set disk_with_partition = disk | combine({'first_partition_id': first_partition}) %}
-          {% set _ = updated_group_disks.append(disk_with_partition) %}
-        {% endfor %}
-        {% set updated_group = {'diskgroup': disk_group.diskgroup, 'disks': updated_group_disks} %}
-        {% set _ = updated_disks.append(updated_group) %}
-      {% endfor %}
-      {{ updated_disks }}
+      {{ new_disks }}
   tags: populate-asm-disks
-

--- a/roles/common/tasks/populate-asm-disks.yml
+++ b/roles/common/tasks/populate-asm-disks.yml
@@ -1,19 +1,23 @@
-- name: Resolve blk_device paths to first partition paths if they exist
+- name: Identify the first partition of the block device based on its persistent identifier (/dev/disk/by-id/)
   ansible.builtin.shell: >
     set -o pipefail;
+    part_path="";
     case "{{ item.blk_device }}" in
+      # If the block device is specified by a persistent identifier, append '-part1' to form the path to the first partition.
       /dev/disk/by-id/*)
         part_path="{{ item.blk_device }}"-part1;
         ;;
+      # Skip /dev/mapper devices since they are typically managed by LVM and do not require partitioning (partitioning logical LVM volumes is not practical).
       /dev/mapper/*)
-        part_path="{{ item.blk_device }}"p1;
+        part_path="";
         ;;
+      # For other devices (E.g.: /dev/sda, /dev/nvme0n1), find the corresponding /dev/disk/by-id/ path and add '-part1' to denote the first partition.
       /dev/*)
         by_id_link=$(find /dev/disk/by-id/ -type l -exec sh -c 'echo $1 $(readlink -f $1)' _ {} \; | awk -v dev="{{ item.blk_device }}" '$2==dev {print $1}' | grep -vE '/dev/disk/by-id/(nvme-|scsi-|wwn-)' | head -n 1);
         part_path="${by_id_link}"-part1;
         ;;
     esac;
-    if [[ -e "$part_path" ]]; then
+    if [[ -e "$part_path" ]] && [[ "$part_path" != "" ]]; then
       echo "$part_path"
     else
       echo ""
@@ -25,19 +29,21 @@
 
 - name: Update asm_disks with partition paths
   set_fact:
-    asm_disks: "{{ asm_disks_updated | from_yaml }}"
-  vars:
-    asm_disks_updated: >
-      {% set new_disks = [] %}
-      {% for disk_group in asm_disks %}
-        {% set new_group_disks = [] %}
-        {% for disk in disk_group.disks %}
-          {% set output = disk_paths.results | selectattr('item.blk_device', 'equalto', disk.blk_device) | map(attribute='stdout') | first %}
-          {% set new_disk = disk | combine({'first_partition_id': output}) %}
-          {% set _ = new_group_disks.append(new_disk) %}
-        {% endfor %}
-        {% set new_disk_group = {'diskgroup': disk_group.diskgroup, 'disks': new_group_disks} %}
-        {% set _ = new_disks.append(new_disk_group) %}
-      {% endfor %}
+    asm_disks: >-
+      {%- set new_disks = [] -%}
+      {%- for disk_group in asm_disks -%}
+        {%- set new_group_disks = [] -%}
+        {%- for disk in disk_group.disks -%}
+          {%- set output = disk_paths.results | selectattr('item.blk_device', 'equalto', disk.blk_device) | map(attribute='stdout') | first -%}
+          {%- if output -%}  
+            {%- set new_disk = disk | combine({'first_partition_id': output}) -%}
+          {%- else -%}
+            {%- set new_disk = disk -%}
+          {%- endif -%}
+          {%- set _ = new_group_disks.append(new_disk) -%}
+        {%- endfor -%}
+        {%- set new_disk_group = {'diskgroup': disk_group.diskgroup, 'disks': new_group_disks} -%}
+        {%- set _ = new_disks.append(new_disk_group) -%}
+      {%- endfor -%}
       {{ new_disks }}
   tags: populate-asm-disks

--- a/roles/common/tasks/populate-swap-partition-id.yml
+++ b/roles/common/tasks/populate-swap-partition-id.yml
@@ -1,14 +1,42 @@
-- name: Collect new disk facts
-  setup:
-    gather_subset:
-      - '!all'
-      - '!any'
-      - devices
-
-- name: Determine the first partition ID of the swap_blk_device
-  set_fact:
-    swap_partition_id: "{{ '/dev/disk/by-id/' + ansible_facts.devices[swap_blk_device | basename].partitions | dict2items  | map(attribute='value.links.ids') | flatten | first() }}"
+- name: Identify the first partition of the swap block device
+  ansible.builtin.shell: >
+    set -o pipefail;
+    part_path="";
+    case "{{ swap_blk_device }}" in
+      # If the block device is specified by a persistent identifier, append '-part1' to form the path to the first partition.
+      /dev/disk/by-id/*)
+        part_path="{{ swap_blk_device }}"-part1;
+        ;;
+      # Skip /dev/mapper devices since they are typically managed by LVM and do not require partitioning (partitioning logical LVM volumes is not practical).
+      /dev/mapper/*)
+        part_path="";
+        ;;
+      # For other devices (E.g.: /dev/sda, /dev/nvme0n1), find the corresponding /dev/disk/by-id/ path and add '-part1' to denote the first partition.
+      /dev/*)
+        by_id_link=$(find /dev/disk/by-id/ -type l -exec sh -c 'echo $1 $(readlink -f $1)' _ {} \; | awk -v dev="{{ swap_blk_device }}" '$2==dev {print $1}' | grep -vE '/dev/disk/by-id/(nvme-|scsi-|wwn-)' | head -n 1);
+        part_path="${by_id_link}"-part1;
+        ;;
+    esac;
+    if [[ -e "$part_path" ]] && [[ "$part_path" != "" ]]; then
+      echo "$part_path"
+    else
+      echo ""
+    fi
+  register: swap_first_partition
   when:
     - swap_blk_device is defined
-    - swap_blk_device | basename in ansible_facts.devices.keys()
-    - ansible_facts.devices[item.blk_device  | basename].partitions.keys()|length > 0
+    - "'mapper' not in swap_blk_device"
+  tags: populate-swap-partition-id
+
+- name: Set swap_partition_id
+  set_fact:
+    swap_partition_id: "{{ swap_first_partition.stdout }}"
+  when:
+  - swap_blk_device is defined
+  - "'mapper' not in swap_blk_device"
+  tags: populate-swap-partition-id
+
+- name: (debug) Display the swap partition ID
+  debug:
+    msg: "{{ swap_partition_id }}"
+  tags: populate-swap-partition-id

--- a/roles/common/tasks/populate-user-data-mounts.yml
+++ b/roles/common/tasks/populate-user-data-mounts.yml
@@ -1,48 +1,40 @@
-- name: Collect new disk facts
-  setup:
-    gather_subset:
-      - '!all'
-      - '!any'
-      - devices
-  tags: populate-user-mounts
-
-- name: Resolve the symlinks
-  ansible.builtin.shell:
-    cmd: "realpath {{ item.blk_device }}"
+- name: Identify the first partition of the block device based on its persistent identifier (/dev/disk/by-id/)
+  ansible.builtin.shell: >
+    set -o pipefail;
+    part_path="";
+    case "{{ item.blk_device }}" in
+      # If the block device is specified by a persistent identifier, append '-part1' to form the path to the first partition.
+      /dev/disk/by-id/*)
+        part_path="{{ item.blk_device }}"-part1;
+        ;;
+      # Skip /dev/mapper devices since they are typically managed by LVM and do not require partitioning (partitioning logical LVM volumes is not practical).
+      /dev/mapper/*)
+        part_path="";
+        ;;
+      # For other devices (E.g.: /dev/sda, /dev/nvme0n1), find the corresponding /dev/disk/by-id/ path and add '-part1' to denote the first partition.
+      /dev/*)
+        by_id_link=$(find /dev/disk/by-id/ -type l -exec sh -c 'echo $1 $(readlink -f $1)' _ {} \; | awk -v dev="{{ item.blk_device }}" '$2==dev {print $1}' | grep -vE '/dev/disk/by-id/(nvme-|scsi-|wwn-)' | head -n 1);
+        part_path="${by_id_link}"-part1;
+        ;;
+    esac;
+    if [[ -e "$part_path" ]] && [[ "$part_path" != "" ]]; then
+      echo "$part_path"
+    else
+      echo ""
+    fi
   loop: "{{ oracle_user_data_mounts }}"
-  register: realpath_result
+  register: disk_paths
   tags: populate-user-mounts
 
-- name: Create a dictionary with blk_device as keys and real_path as values
-  ansible.builtin.set_fact:
-    normalized_blk_device_paths: "{{ dict(realpath_result.results | map(attribute='item.blk_device') | zip(realpath_result.results | map(attribute='stdout'))) }}"
-  tags: populate-user-mounts
 
-- name: Update oracle_user_data_mounts with normalized blk_device paths
-  ansible.builtin.set_fact:
-    oracle_user_data_mounts_normalized: "{{ oracle_user_data_mounts_normalized | default([]) + [item | combine({'blk_device': normalized_blk_device_paths[item.blk_device]})] }}"
-  loop: "{{ oracle_user_data_mounts }}"
-  loop_control:
-    extended: yes
-  tags: populate-user-mounts
-
-- name: Update oracle_user_data_mounts_normalized with first partition IDs
+- name: Update oracle_user_data_mounts with partition paths
   set_fact:
-    oracle_user_data_mounts_with_partitions: "{{ oracle_user_data_mounts_with_partitions | default([]) + [item | combine({'first_partition_id': ('/dev/disk/by-id/' + first_partition_id)})] }}"
-  loop: "{{ oracle_user_data_mounts_normalized }}"
-  loop_control:
-    loop_var: item
-  when:
-    - "'mapper' not in item.blk_device"
-    - item.blk_device  | basename in ansible_facts.devices.keys()
-    - ansible_facts.devices[item.blk_device  | basename].partitions.keys()|length > 0
-  vars:
-    first_partition_id: "{{ ansible_facts.devices[item.blk_device  | basename].partitions | dict2items | map(attribute='value.links.ids') | flatten | first() }}"
-  tags: populate-user-mounts
-
-- name: Update oracle_user_data_mounts
-  set_fact:
-    oracle_user_data_mounts: "{{oracle_user_data_mounts_with_partitions}}"
-  when:
-    - oracle_user_data_mounts_with_partitions is defined
+    oracle_user_data_mounts: >-
+      {%- set updated_mounts = [] -%}
+      {%- for mount in oracle_user_data_mounts -%}
+        {%- set part_result = disk_paths.results | selectattr('item.blk_device', 'equalto', mount.blk_device) | map(attribute='stdout') | first -%}
+        {%- set updated_mount = mount | combine({'first_partition_id': part_result if part_result != '' else ''}) -%}
+        {%- set _ = updated_mounts.append(updated_mount) -%}
+      {%- endfor -%}
+      {{ updated_mounts }}
   tags: populate-user-mounts

--- a/roles/ora-host/tasks/main.yml
+++ b/roles/ora-host/tasks/main.yml
@@ -331,13 +331,6 @@
 - include_role:
     name: common
     tasks_from: populate-asm-disks.yml
-  when: "'mapper' not in outer_item.1.blk_device"
-  run_once: true
-  with_subelements:
-    - "{{ asm_disks }}"
-    - disks
-  loop_control:
-    loop_var: outer_item
 
 - name: (debug) asm disk configuration
   debug:

--- a/roles/rac-gi-setup/tasks/rac-gi-install.yml
+++ b/roles/rac-gi-setup/tasks/rac-gi-install.yml
@@ -109,13 +109,6 @@
 - include_role:
     name: common
     tasks_from: populate-asm-disks.yml
-  when: "'mapper' not in outer_item.1.blk_device"
-  run_once: true
-  with_subelements:
-    - "{{ asm_disks }}"
-    - disks
-  loop_control:
-    loop_var: outer_item
 
 - name: rac-gi-install | Get symlinks for devices
   become: yes


### PR DESCRIPTION
b/332929223

This PR resolves an issue where populate-asm-disks.yml doesn't correctly manage ASM disk groups containing multiple disks.


I have run tests on both a GCE instance and a BMX machine, each configured with multiple disks:


[Installation log from the GCE instance](https://gist.github.com/alex-basinov/5e919a53b67652650be0e625518ac0a7)
[Installation log from the BMX machine](https://gist.github.com/alex-basinov/c6b8e461f8efd1a94b4d202f2c85c72d)