### PR TITLE
Run cvuqdisk search as root

### DIFF
--- a/roles/gi-setup/tasks/gi-install.yml
+++ b/roles/gi-setup/tasks/gi-install.yml
@@ -70,6 +70,8 @@
   tags: gi-setup,sw-unzip
 
 - name: gi-install | Find the cvuqdisk RPM
+  become: yes
+  become_user: root
   find:
     paths: "{{ grid_home }}/cv/rpm/"
     patterns: "*.rpm"


### PR DESCRIPTION
In some cases (possibly involving a re-run of the install without an intervening `cleanup-oracle.sh` run), the grid home gets permissions locked down, so that the ansible user can't read files here.  This change adds a become: (ie sudo) to run the find command as root.  The actual installation already runs as root.

Internal bug reference: b/348132168