### PR TITLE
A minimal fix for broken presubmit tests

### DIFF
--- a/presubmit_tests/test-pr-poc.sh
+++ b/presubmit_tests/test-pr-poc.sh
@@ -26,7 +26,7 @@ ssh-keyscan "${bms_host}" > ~/.ssh/known_hosts
 # install pre-reqs
 pip install jmespath
 cp /etc/files_needed_for_tk/google-cloud-sdk.repo /etc/yum.repos.d/google-cloud-sdk.repo
-yum install google-cloud-sdk -y
+yum --disablerepo=* --enablerepo=google-cloud-sdk -y install google-cloud-sdk
 
 # run the cleanup script
 pwd


### PR DESCRIPTION
The presubmit tests use CentOS Stream 8, which has gone EOL and has had its repos shut down, causing all yum commands to fail.  This hacky fix disables all the repos other than the google cloud one we need.