### PR TITLE
Refactor ASM disk hangling to avoid jinja2 equalto

### DIFF
--- a/roles/common/tasks/populate-asm-disks.yml
+++ b/roles/common/tasks/populate-asm-disks.yml
@@ -26,24 +26,28 @@
   register: disk_paths
   tags: populate-asm-disks
 
-
 - name: Update asm_disks with partition paths
+  vars:
+    blk_device_to_partition: >-
+      {%- set mapping = {} -%}
+      {%- for res in disk_paths.results -%}
+        {%- if res.stdout != '' -%}
+          {%- set _ = mapping.update({res.item.blk_device: res.stdout}) -%}
+        {%- endif -%}
+      {%- endfor -%}
+      {{ mapping }}
   set_fact:
     asm_disks: >-
-      {%- set new_disks = [] -%}
-      {%- for disk_group in asm_disks -%}
-        {%- set new_group_disks = [] -%}
-        {%- for disk in disk_group.disks -%}
-          {%- set output = disk_paths.results | selectattr('item.blk_device', 'equalto', disk.blk_device) | map(attribute='stdout') | first -%}
-          {%- if output -%}  
-            {%- set new_disk = disk | combine({'first_partition_id': output}) -%}
-          {%- else -%}
-            {%- set new_disk = disk -%}
-          {%- endif -%}
-          {%- set _ = new_group_disks.append(new_disk) -%}
+      {%- set updated_disk_groups = [] -%}
+      {%- for group in asm_disks -%}
+        {%- set updated_disks = [] -%}
+        {%- for disk in group.disks -%}
+          {%- set part_result = blk_device_to_partition.get(disk.blk_device, '') -%}
+          {%- set updated_disk = disk | combine({'first_partition_id': part_result}) -%}
+          {{ updated_disks.append(updated_disk) }}
         {%- endfor -%}
-        {%- set new_disk_group = {'diskgroup': disk_group.diskgroup, 'disks': new_group_disks} -%}
-        {%- set _ = new_disks.append(new_disk_group) -%}
+        {%- set updated_group = group | combine({'disks': updated_disks}) -%}
+        {{ updated_disk_groups.append(updated_group) }}
       {%- endfor -%}
-      {{ new_disks }}
+      {{ updated_disk_groups }}
   tags: populate-asm-disks

--- a/roles/common/tasks/populate-user-data-mounts.yml
+++ b/roles/common/tasks/populate-user-data-mounts.yml
@@ -26,15 +26,23 @@
   register: disk_paths
   tags: populate-user-mounts
 
-
 - name: Update oracle_user_data_mounts with partition paths
+  vars:
+    blk_device_to_partition: >-
+      {%- set mapping = {} -%}
+      {%- for res in disk_paths.results -%}
+        {%- if res.stdout != '' -%}
+          {%- set _ = mapping.update({res.item.blk_device: res.stdout}) -%}
+        {%- endif -%}
+      {%- endfor -%}
+      {{ mapping }}
   set_fact:
     oracle_user_data_mounts: >-
       {%- set updated_mounts = [] -%}
       {%- for mount in oracle_user_data_mounts -%}
-        {%- set part_result = disk_paths.results | selectattr('item.blk_device', 'equalto', mount.blk_device) | map(attribute='stdout') | first -%}
-        {%- set updated_mount = mount | combine({'first_partition_id': part_result if part_result != '' else ''}) -%}
-        {%- set _ = updated_mounts.append(updated_mount) -%}
+        {%- set part_result = blk_device_to_partition.get(mount.blk_device, '') -%}
+        {%- set updated_mount = mount | combine({'first_partition_id': part_result}) -%}
+        {{ updated_mounts.append(updated_mount) }}
       {%- endfor -%}
       {{ updated_mounts }}
   tags: populate-user-mounts


### PR DESCRIPTION
Jinja2's `equalto` operator was introduced in 2.8;  some control nodes still run EL7 and return an error:

```
2024-09-05 19:14:10,519 p=5963 u=redacted n=ansible | An exception
occurred during task execution. To see the full traceback, use -vvv. The
error was: TemplateRuntimeError: no test named 'equalto'
```

This change, by alex-basinov, refactors partition checks to avoid the dependency entirely.