### PR TITLE
Fix Ansible warning about using jinja2 template variable delimiters…

### DIFF
--- a/roles/base-provision/tasks/main.yml
+++ b/roles/base-provision/tasks/main.yml
@@ -16,8 +16,8 @@
 - name: Validate OS family and version
   assert:
     that:
-      - "ansible_os_family == '{{ os_family_supported }}'"
-      - "ansible_distribution_version is version_compare('{{ os_min_supported_version }}', '>=')"
+      - "ansible_os_family == os_family_supported"
+      - "ansible_distribution_version is version_compare(os_min_supported_version, '>=')"
   tags: oscheck
 
 - name: Validate architecture


### PR DESCRIPTION
## Problem Description:

Issue with Jinja2 templating in file: `roles/base-provision/tasks/main.yml` as variable delimiters are being used within the conditional statement.

Result is that when run, the following warning is displayed:

```
TASK [Verify that Ansible on control node meets the version requirements] **********************************************************************************************************
ok: [10.2.83.231] => {
    "changed": false,
    "msg": "Ansible version is 2.16.3, continuing"
}
[WARNING]: conditional statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: ansible_os_family == '{{ os_family_supported }}'
[WARNING]: conditional statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: ansible_distribution_version is version_compare('{{
os_min_supported_version }}', '>=')
```

## Solution Overview:

Fix is to remove the Jinja2 variable delimiters which are not required within an Ansible conditional expression.   In this particular case, the assert module’s that parameter value.

## Test Commands:

Test against any release/version with commands such as:

Run toolkit to "prep" stage:

```
./install-oracle.sh \
  --instance-ip-addr ${INSTANCE_IP_ADDR} \
  --ora-edition EE \
  --ora-version 19.3.0.0.0 \
  --ora-swlib-bucket gs://pythian-gto-oracle-software/19c \
  --backup-dest "+RECO" \
  --allow-install-on-vm \
  --prep-host
```

## Expected Result:

No Jinja2 warnings for this specific playbook task:

```
TASK [Verify that Ansible on control node meets the version requirements] **********************************************************************************************************
ok: [10.2.83.231] => {
    "changed": false,
    "msg": "Ansible version is 2.16.3, continuing"
}
```
