### PR TITLE
Remove formatting mistakes and inconsistencies in Markdown and sample JSON files - no changes to runnable files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,73 +2,82 @@
 
 Toolkit for installing and creating an initial Oracle database on [Bare Metal Solution](https://cloud.google.com/bare-metal).
 
-## Quick Start 
+## Quick Start
 
 1. Create a Google Cloud VM to act as a [control node](/docs/user-guide.md#control-node-requirements); it should be on a VPC network that has SSH access to the database hosts.
 1. [Extract the toolkit code](/docs/user-guide.md#installing-the-toolkit) on the control node.
-1. Create a Cloud Storage bucket to host Oracle software images.  
-     ```bash
-     gsutil mb -b on gs://installation-media-1234
-     ```
-1. [Download software](/docs/user-guide.md#downloading-and-staging-the-oracle-software) from Oracle and populate the bucket.  Use [check-swlib.sh](/docs/user-guide.md#validating-media) to determine which files are required for your Oracle version.
+1. Create a Cloud Storage bucket to host Oracle software images.
+   ```bash
+   gsutil mb -b on gs://installation-media-1234
+   ```
+1. [Download software](/docs/user-guide.md#downloading-and-staging-the-oracle-software) from Oracle and populate the bucket. Use [check-swlib.sh](/docs/user-guide.md#validating-media) to determine which files are required for your Oracle version.
 1. Create an SSH key, and populate to an Ansible user on each database host.
 1. Create a JSON file `db1_asm.json` with ASM disk devices:
-    ```json
-    [{
-      "diskgroup": "DATA",
-      "disks": [
-        { "name": "DATA_1", "blk_device": "/dev/mapper/3600a098038314352502b4f782f446155" },
-      ]},
+   ```json
+   [
      {
-      "diskgroup": "RECO",
-      "disks": [
-        { "name": "RECO_1", "blk_device": "/dev/mapper/3600a098038314352502b4f782f446162" },
-      ]}
-    ]
-    ```
+       "diskgroup": "DATA",
+       "disks": [
+         {
+           "name": "DATA_1",
+           "blk_device": "/dev/mapper/3600a098038314352502b4f782f446155"
+         }
+       ]
+     },
+     {
+       "diskgroup": "RECO",
+       "disks": [
+         {
+           "name": "RECO_1",
+           "blk_device": "/dev/mapper/3600a098038314352502b4f782f446162"
+         }
+       ]
+     }
+   ]
+   ```
 1. Create a JSON file `db1_mounts.json` with disk mounts:
-    ```json
-    [
-        {
-            "purpose": "software",
-            "blk_device": "/dev/mapper/3600a098038314352502b4f782f446161",
-            "name": "u01",
-            "fstype":"xfs",
-            "mount_point":"/u01",
-            "mount_opts":"nofail"
-        }
-    ]
-    ```
+   ```json
+   [
+     {
+       "purpose": "software",
+       "blk_device": "/dev/mapper/3600a098038314352502b4f782f446161",
+       "name": "u01",
+       "fstype": "xfs",
+       "mount_point": "/u01",
+       "mount_opts": "nofail"
+     }
+   ]
+   ```
 1. Execute `install-oracle.sh`:
-    ```bash
-    bash install-oracle.sh \
-    --ora-swlib-bucket gs://installation-media-1234 \
-    --instance-ssh-user ansible \
-    --instance-ssh-key ~/.ssh/id_rsa \
-    --backup-dest /u01/rman \
-    --ora-swlib-path /u01/oracle_install \
-    --ora-version 19 \
-    --ora-swlib-type gcs \
-    --ora-asm-disks db1_asm.json \
-    --ora-data-mounts db1_mounts.json \
-    --ora-data-diskgroup DATA \
-    --ora-reco-diskgroup RECO \
-    --ora-db-name orcl \
-    --instance-ip-addr 172.16.1.1
-    ```
+   ```bash
+   bash install-oracle.sh \
+   --ora-swlib-bucket gs://installation-media-1234 \
+   --instance-ssh-user ansible \
+   --instance-ssh-key ~/.ssh/id_rsa \
+   --backup-dest /u01/rman \
+   --ora-swlib-path /u01/oracle_install \
+   --ora-version 19 \
+   --ora-swlib-type gcs \
+   --ora-asm-disks db1_asm.json \
+   --ora-data-mounts db1_mounts.json \
+   --ora-data-diskgroup DATA \
+   --ora-reco-diskgroup RECO \
+   --ora-db-name orcl \
+   --instance-ip-addr 172.16.1.1
+   ```
 
 Full documentation is available in the [user guide](/docs/user-guide.md)
 
 ## Destructive cleanup
 
-An Ansible role and playbook performs a [destructive brute-force removal](/docs/user-guide.md#destructive-cleanup) of Oracle software and configuration.  It does not remove other host prerequisites.
+An Ansible role and playbook performs a [destructive brute-force removal](/docs/user-guide.md#destructive-cleanup) of Oracle software and configuration. It does not remove other host prerequisites.
 
 Run the destructive brute-force Oracle software removal with `cleanup-oracle.sh` or `ansible-playbook brute-cleanup.yml`
 
 ## Contributing to the project
 
-Contributions and pull requests are welcome.  See [docs/contributing.md](docs/contributing.md) and [docs/code-of-conduct.md](docs/code-of-conduct.md) for details.
+Contributions and pull requests are welcome. See [docs/contributing.md](docs/contributing.md) and [docs/code-of-conduct.md](docs/code-of-conduct.md) for details.
 
 ## The fine print
 
-This product is [licensed](LICENSE) under the Apache 2 license.  This is not an officially supported Google project
+This product is [licensed](LICENSE) under the Apache 2 license. This is not an officially supported Google project

--- a/asm_disk_config.json
+++ b/asm_disk_config.json
@@ -1,29 +1,29 @@
 [
-    {
-        "diskgroup": "DATA",
-        "disks": [
-            {
-                "blk_device": "/dev/BOGUS",
-                "name": "DATA1"
-            }
-        ]
-    },
-    {
-        "diskgroup": "RECO",
-        "disks": [
-            {
-                "blk_device": "/dev/BOGUS",
-                "name": "RECO1"
-            }
-        ]
-    },
-    {
-        "diskgroup": "DEMO",
-        "disks": [
-            {
-                "blk_device": "/dev/BOGUS",
-                "name": "DEMO1"
-            }
-        ]
-    }
+  {
+    "diskgroup": "DATA",
+    "disks": [
+      {
+        "blk_device": "/dev/BOGUS",
+        "name": "DATA1"
+      }
+    ]
+  },
+  {
+    "diskgroup": "RECO",
+    "disks": [
+      {
+        "blk_device": "/dev/BOGUS",
+        "name": "RECO1"
+      }
+    ]
+  },
+  {
+    "diskgroup": "DEMO",
+    "disks": [
+      {
+        "blk_device": "/dev/BOGUS",
+        "name": "DEMO1"
+      }
+    ]
+  }
 ]

--- a/cluster_config.json
+++ b/cluster_config.json
@@ -11,17 +11,18 @@
     "scan_ip3": "10.0.1.258",
     "dg_name": "DG_NAME",
     "nodes": [
-      {  "node_name": "host_name",
-         "host_ip": "10.0.0.256",
-         "vip_name": "host_name-vip",
-         "vip_ip": "192.168.0.256"
+      {
+        "node_name": "host_name",
+        "host_ip": "10.0.0.256",
+        "vip_name": "host_name-vip",
+        "vip_ip": "192.168.0.256"
       },
-      {  "node_name": "host_name",
-         "host_ip": "10.0.0.257",
-         "vip_name": "host_name-vip",
-         "vip_ip": "192.168.0.257"
+      {
+        "node_name": "host_name",
+        "host_ip": "10.0.0.257",
+        "vip_name": "host_name-vip",
+        "vip_ip": "192.168.0.257"
       }
     ]
   }
 ]
-

--- a/data_mounts_config.json
+++ b/data_mounts_config.json
@@ -1,10 +1,10 @@
 [
-    {
-        "purpose": "software",
-	"blk_device": "replace_with_block_device_like_/dev/mapper/db-sw",
-	"name": "u01",
-	"fstype":"xfs",
-	"mount_point":"/u01",
-	"mount_opts":"nofail"
-    }
+  {
+    "purpose": "software",
+    "blk_device": "replace_with_block_device_like_/dev/mapper/db-sw",
+    "name": "u01",
+    "fstype": "xfs",
+    "mount_point": "/u01",
+    "mount_opts": "nofail"
+  }
 ]

--- a/docs/code-of-conduct.md
+++ b/docs/code-of-conduct.md
@@ -18,10 +18,10 @@ We value diverse opinions, but we value respectful behavior more.
 
 Respectful behavior includes:
 
-* Being considerate, kind, constructive, and helpful.
-* Not engaging in demeaning, discriminatory, harassing, hateful, sexualized, or
+- Being considerate, kind, constructive, and helpful.
+- Not engaging in demeaning, discriminatory, harassing, hateful, sexualized, or
   physically threatening behavior, speech, and imagery.
-* Not engaging in unwanted physical contact.
+- Not engaging in unwanted physical contact.
 
 Some Google open source projects [may adopt][] an explicit project code of
 conduct, which may have additional detailed expectations for participants. Most
@@ -61,7 +61,7 @@ report supplied to the accused. In potentially harmful situations, such as
 ongoing harassment or threats to anyone's safety, we may take action without
 notice.
 
-*This document was adapted from the [IndieWeb Code of Conduct][] and can also
-be found at <https://opensource.google/conduct/>.*
+_This document was adapted from the [IndieWeb Code of Conduct][] and can also
+be found at <https://opensource.google/conduct/>._
 
 [IndieWeb Code of Conduct]: https://indieweb.org/code-of-conduct

--- a/docs/patch-metadata.md
+++ b/docs/patch-metadata.md
@@ -14,10 +14,11 @@ rdbms_patches:
 ```
 
 These metadata numbers can be taken from consulting appropriate MOS Notes, such as:
-* Master Note for Database Proactive Patch Program (Doc ID 888.1)
-* Oracle Database 19c Proactive Patch Information (Doc ID 2521164.1)
-* Database 18c Proactive Patch Information (Doc ID 2369376.1)
-* Database 12.2.0.1 Proactive Patch Information (Doc ID 2285557.1)
+
+- Master Note for Database Proactive Patch Program (Doc ID 888.1)
+- Oracle Database 19c Proactive Patch Information (Doc ID 2521164.1)
+- Database 18c Proactive Patch Information (Doc ID 2369376.1)
+- Database 12.2.0.1 Proactive Patch Information (Doc ID 2285557.1)
 
 The md5sum can be determined by listing the file once in a GCS bucket:
 
@@ -27,6 +28,7 @@ $ gsutil ls -L gs://example-bucket/p32578973_190000_Linux-x86-64.zip | grep md5
 ```
 
 Bearing in mind that the GI RU's patch zipfile contains the patch molecules that go both into the GI_HOME as well as the RDBMS_HOME, the Combo patch of OJVM+GI is self-contained as to the necessary patches needed to patch a given host for a given quarter. For example: the patch zipfile `p31720429_190000_Linux-x86-64.zip` contains the following patch directories:
+
 ```
 ├── 31720429
 │   ├── 31668882  <================ this is the OJVM RU for that quarter
@@ -48,4 +50,5 @@ Bearing in mind that the GI RU's patch zipfile contains the patch molecules that
 └── PatchSearch.xml
 
 ```
+
 Accordingly the patch_subdir values can be edited, as noted in the foregoing.

--- a/docs/troubleshooting_guide.md
+++ b/docs/troubleshooting_guide.md
@@ -1,4 +1,5 @@
 # Troubleshooting guide
+
 Running into an error? Here are a few sample error messages and solutions.
 
 ## Table of Contents:
@@ -6,26 +7,28 @@ Running into an error? Here are a few sample error messages and solutions.
 <!-- TOC depthFrom:1 depthTo:6 withLinks:1 updateOnSave:1 orderedList:0 -->
 
 - [Troubleshooting guide](#troubleshooting-guide)
-	- [Table of Contents:](#table-of-contents)
-	- [Missing `dg_name` in `cluster_config.json` file](#missing-dgname-in-clusterconfigjson-file)
-	- [Invalid diskgroup name in `asm_disk_config.json`](#invalid-diskgroup-name-in-asmdiskconfigjson)
-	- [Invalid network interface name in `cluster_config.json`](#invalid-network-interface-name-in-clusterconfigjson)
-	- [ASM candidate disks having a header containing old DG data](#asm-candidate-disks-having-a-header-containing-old-dg-data)
-	- [Existing ORACLE_HOME](#existing-oraclehome)
-	- [First time connection errors to target host from cloud VM](#first-time-connection-errors-to-target-host-from-cloud-vm)
-	- [Failing gcscopy step](#failing-gcscopy-step)
-	- [Time offset between RAC cluster nodes](#time-offset-between-rac-cluster-nodes)
-	- [Pass extra flags into ansible via `install-oracle.sh`:](#pass-extra-flags-into-ansible-via-install-oraclesh)
+  - [Table of Contents:](#table-of-contents)
+  - [Missing `dg_name` in `cluster_config.json` file](#missing-dgname-in-clusterconfigjson-file)
+  - [Invalid diskgroup name in `asm_disk_config.json`](#invalid-diskgroup-name-in-asmdiskconfigjson)
+  - [Invalid network interface name in `cluster_config.json`](#invalid-network-interface-name-in-clusterconfigjson)
+  - [ASM candidate disks having a header containing old DG data](#asm-candidate-disks-having-a-header-containing-old-dg-data)
+  - [Existing ORACLE_HOME](#existing-oraclehome)
+  - [First time connection errors to target host from cloud VM](#first-time-connection-errors-to-target-host-from-cloud-vm)
+  - [Failing gcscopy step](#failing-gcscopy-step)
+  - [Time offset between RAC cluster nodes](#time-offset-between-rac-cluster-nodes)
+  - [Pass extra flags into ansible via `install-oracle.sh`:](#pass-extra-flags-into-ansible-via-install-oraclesh)
 
 <!-- /TOC -->
+
 ## Missing `dg_name` in `cluster_config.json` file
-* Error:
+
+- Error:
 
 ```
 fatal: [racnode1.orcl]: FAILED! => {"msg": "'ansible.vars.hostvars.HostVarsVars object' has no attribute 'dg_name'"}
 ```
 
-* Possible place to check will be `bms-toolkit/cluster_config.json`:
+- Possible place to check will be `bms-toolkit/cluster_config.json`:
 
 ```json
 [
@@ -57,7 +60,8 @@ fatal: [racnode1.orcl]: FAILED! => {"msg": "'ansible.vars.hostvars.HostVarsVars 
 ```
 
 ## Invalid diskgroup name in `asm_disk_config.json`
-* For following error:
+
+- For following error:
 
 ```
 TASK [rac-gi-setup : rac-gi-install | Get symlinks for devices] ************************************************************************************************
@@ -68,14 +72,15 @@ fatal: [racnode1.orcl]: FAILED! => {
 }
 ```
 
-* Check that: `dg_name=DATA` points to a valid diskgroup name.
-* Rationale: the following expression in the [source code](https://github.com/google/bms-toolkit/blob/master/roles/rac-gi-setup/tasks/rac-gi-install.yml#L133):
+- Check that: `dg_name=DATA` points to a valid diskgroup name.
+- Rationale: the following expression in the [source code](https://github.com/google/bms-toolkit/blob/master/roles/rac-gi-setup/tasks/rac-gi-install.yml#L133):
 
 ```
 "{{ asm_disks | json_query('[?diskgroup==`' + hostvars[groups['dbasm'].0]['dg_name'] + '`].disks[*].blk_device') | list | join() }}"
 ```
 
 ... translates to something similar to the following:
+
 ```
 "{{ asm_disks | json_query('[?diskgroup==`'DATA'`].disks[*].blk_device') | list | join() }}"
 ```
@@ -83,14 +88,17 @@ fatal: [racnode1.orcl]: FAILED! => {
 where the 'DATA' is the incorrect DG name supplied in `cluster_config.json` file's `"dg_name": "DATA"`
 
 ## Invalid network interface name in `cluster_config.json`
-* Error:
+
+- Error:
+
 ```
 TASK [rac-gi-setup : rac-gi-install | Create GI response file] *************************************************************************************************
 fatal: [racnode1.orcl]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'dict object' has no attribute u'dec-test-public_interface'"}
 ```
 
-* Fix:
-Ensure that the entries for the n/w interfaces are correctly defined in `cluster_config.json`:
+- Fix:
+  Ensure that the entries for the n/w interfaces are correctly defined in `cluster_config.json`:
+
 ```json
 [
   {
@@ -105,15 +113,17 @@ Ensure that the entries for the n/w interfaces are correctly defined in `cluster
     "scan_ip3": "172.16.30.22",
     "dg_name": "DATA",
     "nodes": [
-      {  "node_name": "racnode1.orcl",
-         "host_ip": "172.16.30.1",
-         "vip_name": "racnode1-vip.orcl",
-         "vip_ip": "172.16.30.11"
+      {
+        "node_name": "racnode1.orcl",
+        "host_ip": "172.16.30.1",
+        "vip_name": "racnode1-vip.orcl",
+        "vip_ip": "172.16.30.11"
       },
-      {  "node_name": "racnode2.orcl",
-         "host_ip": "172.16.30.2",
-         "vip_name": "racnode2-vip.orcl",
-         "vip_ip": "172.16.30.12"
+      {
+        "node_name": "racnode2.orcl",
+        "host_ip": "172.16.30.2",
+        "vip_name": "racnode2-vip.orcl",
+        "vip_ip": "172.16.30.12"
       }
     ]
   }
@@ -121,7 +131,9 @@ Ensure that the entries for the n/w interfaces are correctly defined in `cluster
 ```
 
 The interface to be used for `public_net` is the interface that carries the network address for the `172.16.30.0` (in the example above) network.
-* Example:
+
+- Example:
+
 ```bash
 [root@racnode1 ~]# ifconfig -a bond0.111
 bond0.111: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
@@ -150,7 +162,8 @@ bond1.112: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
 
 ## ASM candidate disks having a header containing old DG data
 
-* Error:
+- Error:
+
 ```
 SEVERE:  [Jan 20, 2021 7:42:09 AM] [FATAL] [INS-30530] Following specified disks have invalid header status:
 [/dev/asmdisks/DATA_7539397476, /dev/asmdisks/DATA_7539397477, /dev/asmdisks/DATA_7539397478, /dev/asmdisks/DATA_7539397531]
@@ -158,9 +171,10 @@ SEVERE:  [Jan 20, 2021 7:42:09 AM] [FATAL] [INS-30530] Following specified disks
 
 This means that the disks that are listed in the `asm_disk_config.json` file carry existing ASM disk metadata, possibly from a prior failed installation attempt. Ideally disk headers input in the json file should be empty. Care should be taken to ensure that disk corruption or loss of data in a disk is not introduced.
 
-* Fix: Possibly the last time `cleanup-oracle.sh` was run, it didn't go through till the end, as it zeroes out headers cleanly for you.
+- Fix: Possibly the last time `cleanup-oracle.sh` was run, it didn't go through till the end, as it zeroes out headers cleanly for you.
 
 Following command can be used to check if the headers contain ASM metadata:
+
 ```bash
 for i in /dev/asmdisks/DATA_7539397476, /dev/asmdisks/DATA_7539397477, /dev/asmdisks/DATA_7539397478, /dev/asmdisks/DATA_7539397531 ; \
 do echo "checking disk $i";dd if=$i bs=128 count=1 | od -a ;echo; \
@@ -168,6 +182,7 @@ done
 ```
 
 You will see something like this which shows that the disk headers are not empty and it has remnant DG information:
+
 ```
 checking disk /dev/asmdisks/DATA_7539397476
 1+0 records in
@@ -184,7 +199,8 @@ checking disk /dev/asmdisks/DATA_7539397476
 0000200
 ```
 
-* For cleanup, the `cleanup-oracle.sh` can be run again, or the following snippet if specific disks (that were listed in the ansible error messages) need to be cleaned out quickly to unblockthe install quickly as:
+- For cleanup, the `cleanup-oracle.sh` can be run again, or the following snippet if specific disks (that were listed in the ansible error messages) need to be cleaned out quickly to unblock the install quickly as:
+
 ```
  #First backup:
 dd if=/dev/asmdisks/DATA_7539397476 of=dev_asmdisks_DATA_7539397476.txt bs=1048576 count=100
@@ -196,18 +212,20 @@ do dd if=/dev/zero of=$i bs=1048576 count=100 ;echo Done blowing up header for d
 
 ## Existing ORACLE_HOME
 
-* Error:
+- Error:
+
 ```
 "Launching Oracle Grid Infrastructure Setup Wizard...", "", "[WARNING] [INS-40109] The specified Oracle Base location is not empty on this server.", "   ACTION: Specify an empty location for Oracle Base.", "[WARNING] [INS-32047] The location (/u01/app/oraInventory) specified for the central inventory is not empty.", "   ACTION: It is recommended to provide an empty location for the inventory.", "[FATAL] [INS-13019] Some mandatory prerequisites are not met. These prerequisites cannot be ignored."
 ```
 
-* Fix:
-Rerun `cleanup-oracle.sh` and ensure it finished successfully (it can fail at the part where it tries to umount the u01 mountpoint and exits at that point)
+- Fix:
+  Rerun `cleanup-oracle.sh` and ensure it finished successfully (it can fail at the part where it tries to umount the u01 mountpoint and exits at that point)
 
 ## First time connection errors to target host from cloud VM
-* Make sure you have a user and appropriate authentication set up on the target host. By default it uses your own OS user id but can use ``--instance-ssh-user` to use a different-user, and ``--instance-ssh-key` to specify a SSH private key file to use.
-* You will need to generate ssh public and private keys, store the public key under the home directory of the `ansible` OS user in the BM host and the private keys under their OS account in cloud VM.
-* Sample connectivity error may be of the form similar to:
+
+- Make sure you have a user and appropriate authentication set up on the target host. By default it uses your own OS user id but can use `--instance-ssh-user` to use a different-user, and `--instance-ssh-key` to specify a SSH private key file to use.
+- You will need to generate ssh public and private keys, store the public key under the home directory of the `ansible` OS user in the BM host and the private keys under their OS account in cloud VM.
+- Sample connectivity error may be of the form similar to:
 
 ```
 TASK [Test connectivity to target instance via ping] ***********************************************************************************************************
@@ -215,24 +233,26 @@ fatal: [racnode1.orcl]: UNREACHABLE! => {"changed": false, "msg": "Failed to con
 fatal: [racnode2.orcl]: UNREACHABLE! => {"changed": false, "msg": "Failed to connect to the host via ssh: Warning: Permanently added '172.16.30.2' (ECDSA) to the list of known hosts.\r\nno such identity: /home/janedoe/.ssh/id_rsa: No such file or directory\r\nPermission denied (publickey,gssapi-keyex,gssapi-with-mic,password).", "unreachable": true}
 ```
 
-* Fix:
-Reason for the error is as follows:
-* By, `--instance-ssh-user ansible --instance-ssh-key ~/.ssh/id_rsa` typically provided in the command line to `install-oracle.sh`, we are asking Ansible to connect:
-  * from the current jump host/VM as the user (say) `janedoe`
-  * to the BM host as the OS user called `ansible`
-  * using the SSH key file in the jump host under the current users home directory's: `~/.ssh/id_rsa`
+- Fix:
+  Reason for the error is as follows:
+- By, `--instance-ssh-user ansible --instance-ssh-key ~/.ssh/id_rsa` typically provided in the command line to `install-oracle.sh`, we are asking Ansible to connect:
+  - from the current jump host/VM as the user (say) `janedoe`
+  - to the BM host as the OS user called `ansible`
+  - using the SSH key file in the jump host under the current users home directory's: `~/.ssh/id_rsa`
 
-As noted in [bms documentation](https://github.com/google/bms-toolkit/blob/master/docs/user-guide.md#command-quick-reference-for-rac-deployments
-):
+As noted in [bms documentation](https://github.com/google/bms-toolkit/blob/master/docs/user-guide.md#command-quick-reference-for-rac-deployments):
 we want to ensure we can connect to the backend nodes with ssh and sudo to the account we want ansible to escalate to:
+
 ```bash
 ssh ${INSTANCE_SSH_USER:-`whoami`}@${INSTANCE_IP_ADDR_NODE_1} sudo -u root hostname
 ssh ${INSTANCE_SSH_USER:-`whoami`}@${INSTANCE_IP_ADDR_NODE_2} sudo -u root hostname
 ```
+
 Some references for enabling this can be found [here](https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-configure-a-jump-host-to-access-servers-that-i-have-no-direct-access-to) and [here](https://blog.scottlowe.org/2015/12/24/running-ansible-through-ssh-bastion-host/)
 
-Summarizing into handy commands from the references, to enable passwordless ssh connectivity and to set up that connection manually, following actions may be performed:
-* Generate a public/private key pair:
+Summarizing into handy commands from the references, to enable password-less ssh connectivity and to set up that connection manually, following actions may be performed:
+
+- Generate a public/private key pair:
 
 ```bash
 [janedoe@control-host-cloudvm .ssh]$ which ssh-keygen
@@ -270,13 +290,15 @@ drwx------. 9 janedoe janedoe  237 Dec 15 19:06 ..
 -rw-------. 1 janedoe janedoe 3243 Dec 16 15:39 id_rsa.  <======= Should be protected
 drwxrwxr-x. 2 janedoe janedoe   97 Dec 16 15:39 .
 ```
-* and post the public key on to the `ansible` users HOME/.ssh/authorized_keys file using one of 2 options:
-  * if you know the password of the ansible user:
+
+- and post the public key on to the `ansible` users HOME/.ssh/authorized_keys file using one of 2 options:
+  - if you know the password of the ansible user:
+
 ```bash
 [janedoe@control-host-cloudvm .ssh]$ ssh-copy-id ansible@172.16.30.1
 ```
 
- * if that's unknown, then simply copy the contents of the publickey and append it into the authorized_keys file:
+- if that's unknown, then simply copy the contents of the public key and append it into the `authorized_keys` file:
 
 ```bash
 [ansible@racnode1 .ssh]$ cat >> authorized_keys
@@ -284,29 +306,34 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC<more crypto> janedoe@control-host-cloudv
 ```
 
 ## Failing gcscopy step
-* The following failure may be encountered during running `gcscopy.yml` playbook:
+
+- The following failure may be encountered during running `gcscopy.yml` playbook:
+
 ```bash
 failed: [racnode1.orcl] (item={u'files': [u'V982068-01.zip'], u'version': u'19.3.0.0.0', u'name': u'19c_gi', u'sha256sum': [u'D668002664D9399CF61EB03C0D1E3687121FC890B1DDD50B35DCBE13C5307D2E']}) => {"ansible_loop_var": "item", "changed": false, "item": {"files": ["V982068-01.zip"], "name": "19c_gi", "sha256sum": ["D668002664D9399CF61EB03C0D1E3687121FC890B1DDD50B35DCBE13C5307D2E"], "version": "19.3.0.0.0"}, "module_stderr": "sudo: a password is required\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
 ```
 
-* Fix:
-  * This means that the current OS user executing the toolkit from the cloud VM is lacking sudo privileges
-  * Add the OS user in the cloud VM to the OS user group wheel that has appropriate sudo privileges.
+- Fix:
+  - This means that the current OS user executing the toolkit from the cloud VM is lacking sudo privileges
+  - Add the OS user in the cloud VM to the OS user group wheel that has appropriate sudo privileges.
 
 ## Time offset between RAC cluster nodes
-* Ansible error:
+
+- Ansible error:
+
 ```bash
 "[FATAL] [INS-13019] Some mandatory prerequisites are not met. These prerequisites cannot be ignored.",
-"   CAUSE: The following prerequisites are mandatory and cannot be ignored: ", "- Time offset between nodes", "  
+"   CAUSE: The following prerequisites are mandatory and cannot be ignored: ", "- Time offset between nodes", "
 ```
 
-* Fix:
-  * RAC nodes need an NTP server to synchronize time.
-  * It is recommeded to have a time server
-  * In the case that there are no existing NTP servers, it is recommended to use the time.google.com, if the host has internet access.
-  * The following flag may be used with `install-oracle.sh` to provide the name of the NTP server that needs to be used:`--ntp-pref`
+- Fix:
 
-  * The above will mimic following manual fix:
+  - RAC nodes need an NTP server to synchronize time.
+  - It is recommended to have a time server
+  - In the case that there are no existing NTP servers, it is recommended to use the time.google.com, if the host has internet access.
+  - The following flag may be used with `install-oracle.sh` to provide the name of the NTP server that needs to be used:`--ntp-pref`
+
+  - The above will mimic following manual fix:
 
 ```
 [root@control-host-cloudvm ~]# #Add this longer line in cloud VM host:
@@ -338,8 +365,10 @@ Thu Jan 21 22:40:31 UTC 2021
 Thu Jan 21 22:40:34 UTC 2021
 ```
 
-## Pass extra flags into ansible via `install-oracle.sh` 
-* There may arise situations where we may want to pass extra flags to ansible and this may be done as follows (taking an example of passing the debug flag):
+## Pass extra flags into ansible via `install-oracle.sh`
+
+- There may arise situations where we may want to pass extra flags to ansible and this may be done as follows (taking an example of passing the debug flag):
+
 ```bash
  ~/git-clone-holder/bms-toolkit [master L|✚ 3…2]
 23:17 $ ./install-oracle.sh \
@@ -361,7 +390,7 @@ Thu Jan 21 22:40:34 UTC 2021
 -- -vvvv 2>&1   <-----------------------------------------------------------------------------
 ```
 
-* `-- -vvvv` will be sent by the wrapper install-oracle.sh into Ansible as:
+- `-- -vvvv` will be sent by the wrapper install-oracle.sh into Ansible as:
 
 ```bash
 Ansible params: -vvvv
@@ -370,16 +399,16 @@ Found Ansible at /usr/bin/ansible-playbook
 Running Ansible playbook: /usr/bin/ansible-playbook -i ./inventory_files/inventory_orcl_RAC  -vvvv check-instance.yml
 ```
 
-* Debug tip: if you are testing a **specific functionality** of a playbook by extracting snippets of the playbook into your local ansible setup, don't turn off the `gather_facts` (by inadvertently having the setting `gather_facts: False` in your test playbook).
+- Debug tip: if you are testing a **specific functionality** of a playbook by extracting snippets of the playbook into your local ansible setup, don't turn off the `gather_facts` (by inadvertently having the setting `gather_facts: False` in your test playbook).
 
 ## Conditional check failure on AnsibleUnsafeText
 
-* A playbook may report a missing attribute on an AnsibleUnsafeText object:
+- A playbook may report a missing attribute on an AnsibleUnsafeText object:
 
 ```
   TASK [host-storage : Partition Oracle user mount devices] **************************************************************************************************************************************************************************************************************************************************************
   fatal: [racnode1.orcl]: FAILED! => {"msg": "The conditional check ''mapper' not in item.blk_device' failed. The error was: error while evaluating conditional ('mapper' not in item.blk_device): 'ansible.utils.unsafe_proxy.AnsibleUnsafeText object' has no attribute 'blk_device'\n\nThe error appears to be in '/home/mfielding/git/opatch/roles/host-storage/tasks/main.yml': line 16, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n---\n- name: Partition Oracle user mount devices\n  ^ here\n"}
 ```
 
-* Fix:
-  * Ansible is not able to parse an input JSON file.  Identify the input file involved, and validate.  Is there a blank line, perhaps?
+- Fix:
+  - Ansible is not able to parse an input JSON file. Identify the input file involved, and validate. Is there a blank line, perhaps?

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -62,10 +62,10 @@ options, and usage scenarios. All commands run from the "control node".
 
 1. Validate media specifying GCS storage bucket and optionally database:
 
-    ```bash
-    ./check-swlib.sh --ora-swlib-bucket gs://[cloud-storage-bucket-name] \
-     --ora-version 19.3.0.0.0
-    ```
+   ```bash
+   ./check-swlib.sh --ora-swlib-bucket gs://[cloud-storage-bucket-name] \
+    --ora-version 19.3.0.0.0
+   ```
 
 1. Validate access to target server (optionally include -i and location of
    private key file):
@@ -106,10 +106,10 @@ Initial steps similar to those of the Single Instance installation.
 
 1. Validate access to target RAC nodes:
 
-    ```bash
-    ssh ${INSTANCE_SSH_USER:-`whoami`}@${INSTANCE_IP_ADDR_NODE_1} sudo -u root hostname
-    ssh ${INSTANCE_SSH_USER:-`whoami`}@${INSTANCE_IP_ADDR_NODE_2} sudo -u root hostname
-    ```
+   ```bash
+   ssh ${INSTANCE_SSH_USER:-`whoami`}@${INSTANCE_IP_ADDR_NODE_1} sudo -u root hostname
+   ssh ${INSTANCE_SSH_USER:-`whoami`}@${INSTANCE_IP_ADDR_NODE_2} sudo -u root hostname
+   ```
 
 1. Review optional toolkit parameters:
 
@@ -136,6 +136,7 @@ The primary database must exist before you can create a standby database.
 When you create the primary database, omit the `--cluster-type` option or set it to `NONE`. To create the primary database, see [Single Instance Deployments section](#command-quick-reference-for-single-instance-deployments).
 
 To create a standby database, add the following options to the command options that you used to create the primary database:
+
 - `--primary-ip-addr ${PRIMARY_IP_ADDR}`
 - `--cluster-type DG`
 
@@ -151,7 +152,6 @@ To create a standby database, add the following options to the command options t
    --primary-ip-addr ${PRIMARY_IP_ADDR} \
    --cluster-type DG
    ```
-
 
 ## Overview
 
@@ -236,7 +236,7 @@ The control node can be any server capable of ssh.
 
 The control node must have the following software installed:
 
-- [Ansible]([https://en.wikipedia.org/wiki/Ansible_(software)](https://en.wikipedia.org/wiki/Ansible_(software)))
+- [Ansible](https://en.wikipedia.org/wiki/Ansible_(software))
   version 2.9 or higher.
 - If you are using a Cloud Storage bucket to stage your Oracle installation
   media, the [Google Cloud SDK](https://cloud.google.com/sdk/docs).
@@ -299,11 +299,11 @@ Cloud](https://edelivery.oracle.com/) site (also known as Oracle "eDelivery"),
 and **patches** that you download from Oracle's [My Oracle
 Support](https://support.oracle.com/) (MOS) site.
 
-You can also download base software from 
-[Oracle Technology Network][https://www.oracle.com/database/technologies/oracle-database-software-downloads.html#db_ee).
+You can also download base software from
+[Oracle Technology Network](https://www.oracle.com/database/technologies/oracle-database-software-downloads.html#db_ee).
 In this case, please rename the downloaded files to the
 [software delivery cloud equivalent](#required-oracle-software---download-summary)
-names, and use `--no-patch` to skip patching.  Note that unpatched software may
+names, and use `--no-patch` to skip patching. Note that unpatched software may
 have known defects and security vulnerabilities.
 
 One key exception: Oracle 11g base software can be downloaded directly from My
@@ -315,7 +315,7 @@ Before you download Oracle software and patches, review and acknowledge Oracle's
 license terms.
 
 Before using the toolkit, download all of the software pieces for your Oracle
-release, including the base release, patchsets, the OPatch utility, and any
+release, including the base release, patch sets, the OPatch utility, and any
 additional patches listed by Oracle (unless using `--no-patch`, at which
 point only the base release is installed).
 
@@ -391,8 +391,6 @@ Support")</th>
 <td>COMBO OF OJVM RU COMPONENT 19.10.0.0.210119 + GI RU 19.10.0.0.210119</td>
 <td>p32126842_190000_Linux-x86-64.zip</td>
 </tr>
-
-
 
 <tr>
 <td></td>
@@ -528,7 +526,7 @@ x86-64</td>
 <td></td>
 <td>Patch - MOS</td>
 <td>COMBO OF OJVM RU COMPONENT 12.2.0.1.211019 + 12.2.0.1.211019 GIOCT2021RU</td>
-<td>p333248546_122010_Linux-x86-64.zip</td>
+<td>p33248546_122010_Linux_Linux-x86-64.zip</td>
 </tr>
 <tr>
 <td></td>
@@ -948,22 +946,22 @@ file:
 
 ```json
 [
-    {
-        "purpose": "software",
-        "blk_device": "/dev/mapper/3600a098038314352502b4f782f446138",
-        "name": "u01",
-        "fstype":"xfs",
-        "mount_point":"/u01",
-        "mount_opts":"nofail"
-    },
-    {
-        "purpose": "diag",
-        "blk_device": "/dev/mapper/3600a098038314352502b4f782f446230",
-        "name": "u02",
-        "fstype":"xfs",
-        "mount_point":"/u02",
-        "mount_opts":"nofail"
-    }
+  {
+    "purpose": "software",
+    "blk_device": "/dev/mapper/3600a098038314352502b4f782f446138",
+    "name": "u01",
+    "fstype": "xfs",
+    "mount_point": "/u01",
+    "mount_opts": "nofail"
+  },
+  {
+    "purpose": "diag",
+    "blk_device": "/dev/mapper/3600a098038314352502b4f782f446230",
+    "name": "u02",
+    "fstype": "xfs",
+    "mount_point": "/u02",
+    "mount_opts": "nofail"
+  }
 ]
 ```
 
@@ -974,7 +972,7 @@ names, and the associated block devices (the actual devices, not partitions) in
 valid JSON format.
 
 When you run the toolkit, specify the path to the configuration file by using
-either the  `--ora-asm-disks` command line option or the `ORA_ASM_DISKS`
+either the `--ora-asm-disks` command line option or the `ORA_ASM_DISKS`
 environment variable. The file path can be relative or fully qualified. The file
 name defaults to `ask_disk_config.json`.
 
@@ -982,23 +980,26 @@ The following example shows a properly formatted JSON ASM disk group
 configuration file:
 
 ```json
-[{
-  "diskgroup": "DATA",
-  "disks": [
-    { "name": "DATA_1234567538", "blk_device": "/dev/mapper/3600a098038314344382b4f1234567538" },
-    { "name": "DATA_123456752D", "blk_device": "/dev/mapper/3600a098038314344382b4f123456752d" },
-    { "name": "DATA_1234567541", "blk_device": "/dev/mapper/3600a098038314344382b4f1234567541" },
-    { "name": "DATA_1234567542", "blk_device": "/dev/mapper/3600a098038314344382b4f1234567542" },
-    { "name": "DATA_1234567543", "blk_device": "/dev/mapper/3600a098038314344382b4f1234567543" },
-    { "name": "DATA_1234567544", "blk_device": "/dev/mapper/3600a098038314344382b4f1234567544" },
-  ]},
- {
-  "diskgroup": "RECO",
-  "disks": [
-    { "name": "RECO_1234567546", "blk_device": "/dev/mapper/3600a098038314344382b4f1234567546" },
-    { "name": "RECO_1234567547", "blk_device": "/dev/mapper/3600a098038314344382b4f1234567547" },
-    { "name": "RECO_1234567548", "blk_device": "/dev/mapper/3600a098038314344382b4f1234567548" },
-  ]}
+[
+  {
+    "diskgroup": "DATA",
+    "disks": [
+      { "name": "DATA_1234567538", "blk_device": "/dev/mapper/3600a098038314344382b4f1234567538" },
+      { "name": "DATA_123456752D", "blk_device": "/dev/mapper/3600a098038314344382b4f123456752d" },
+      { "name": "DATA_1234567541", "blk_device": "/dev/mapper/3600a098038314344382b4f1234567541" },
+      { "name": "DATA_1234567542", "blk_device": "/dev/mapper/3600a098038314344382b4f1234567542" },
+      { "name": "DATA_1234567543", "blk_device": "/dev/mapper/3600a098038314344382b4f1234567543" },
+      { "name": "DATA_1234567544", "blk_device": "/dev/mapper/3600a098038314344382b4f1234567544" }
+    ]
+  },
+  {
+    "diskgroup": "RECO",
+    "disks": [
+      { "name": "RECO_1234567546", "blk_device": "/dev/mapper/3600a098038314344382b4f1234567546" },
+      { "name": "RECO_1234567547", "blk_device": "/dev/mapper/3600a098038314344382b4f1234567547" },
+      { "name": "RECO_1234567548", "blk_device": "/dev/mapper/3600a098038314344382b4f1234567548" }
+    ]
+  }
 ]
 ```
 
@@ -1825,9 +1826,9 @@ instance is created.</td>
 In the following example, environment variables are used to specify the
 following values:
 
--  The IP address of the target instance
--  The Oracle release
--  The database name
+- The IP address of the target instance
+- The Oracle release
+- The database name
 
 For all other parameters, the default values are accepted.
 
@@ -2147,11 +2148,11 @@ You can apply Oracle Release Update (RU) or Patch Set Update (PSU) patches to
 both the Grid Infrastructure and Database homes by using the
 `apply-patch.sh` script of the toolkit.
 
-By default, `install-oracle.sh` updates to the latest available patch.  To
+By default, `install-oracle.sh` updates to the latest available patch. To
 apply a specific patch instead, use the `--no-patch` option in `install-oracle.sh`
-to skip patching at installation time.  After installation is complete,  execute
-`apply-patch.sh` with the `--ora-release` option.  Specify the full release name including
-timestamp;  a list of release names is available in
+to skip patching at installation time. After installation is complete, execute
+`apply-patch.sh` with the `--ora-release` option. Specify the full release name including
+timestamp; a list of release names is available in
 https://github.com/google/bms-toolkit/tree/master/roles/common/defaults/main.yml
 under `gi-patches` and `rdbms-patches`.
 
@@ -2214,6 +2215,7 @@ TASK [patch : Update OPatch in GRID_HOME]
 
 ... output truncated for brevity
 ```
+
 #### A note on patch metadata
 
 See [patching-metadata.md](./patching-metadata.md) for details on
@@ -2306,10 +2308,32 @@ both the GI and RDBMS software:
 
 ```yaml
 gi_patches:
-  - { category: "RU", base: "19.3.0.0.0", release: "19.7.0.0.200414", patchnum: "30783556", patchfile: "p30783556_190000_Linux-x86-64.zip", patch_subdir: "/30899722", prereq_check: FALSE, method: "opatchauto apply", ocm: FALSE, upgrade: FALSE }
+  - {
+      category: "RU",
+      base: "19.3.0.0.0",
+      release: "19.7.0.0.200414",
+      patchnum: "30783556",
+      patchfile: "p30783556_190000_Linux-x86-64.zip",
+      patch_subdir: "/30899722",
+      prereq_check: FALSE,
+      method: "opatchauto apply",
+      ocm: FALSE,
+      upgrade: FALSE,
+    }
 
 rdbms_patches:
-  - { category: "RU_Combo", base: "19.3.0.0.0", release: "19.7.0.0.200414", patchnum: "30783556", patchfile: "p30783556_190000_Linux-x86-64.zip", patch_subdir: "/30805684", prereq_check: TRUE, method: "opatch apply", ocm: FALSE, upgrade: TRUE }
+  - {
+      category: "RU_Combo",
+      base: "19.3.0.0.0",
+      release: "19.7.0.0.200414",
+      patchnum: "30783556",
+      patchfile: "p30783556_190000_Linux-x86-64.zip",
+      patch_subdir: "/30805684",
+      prereq_check: TRUE,
+      method: "opatch apply",
+      ocm: FALSE,
+      upgrade: TRUE,
+    }
 ```
 
 The following example shows the specification of the YAML file by using the
@@ -2368,11 +2392,11 @@ destructive or a brute-force clean-up of Oracle databases, services, and
 software from a specified target database server. A brute-force clean-up takes
 the following actions:
 
--  Kills all running Oracle services.
--  Deconfigures the Oracle Restart software.
--  Removes Oracle related directories and files.
--  Removes Oracle software owner users and groups.
--  Re-initializes ASM storage devices and uninstalls ASMlib if installed.
+- Kills all running Oracle services.
+- Deconfigures the Oracle Restart software.
+- Removes Oracle related directories and files.
+- Removes Oracle software owner users and groups.
+- Re-initializes ASM storage devices and uninstalls ASMlib if installed.
 
 **Important**: a destructive cleanup permanently deletes the databases and any data they
 contain. Any backups that are stored local to the server are also deleted. Backups

--- a/roles/brute-ora-cleanup/README.md
+++ b/roles/brute-ora-cleanup/README.md
@@ -1,8 +1,8 @@
 # Oracle Brute Force Clean-up
 
-*Caution - destructive tasks - will permanentally erase software*
+_Caution - destructive tasks - will permanentally erase software_
 
-Role to do a brute force removal of all Oracle software on server.  Run with Oracle/GI services up.
+Role to do a brute force removal of all Oracle software on server. Run with Oracle/GI services up.
 
 Sample execution:
 
@@ -10,8 +10,7 @@ Sample execution:
 ansible-playbook brute-cleanup.yml --extra-vars "oracle_ver=11.2.0.4.0"
 ```
 
+## Items not covered
 
-## Items not covered ##
-
-* Removal of ASMlib packages (if installed)
-* Removal of udev rules (if configured)
+- Removal of ASMlib packages (if installed)
+- Removal of udev rules (if configured)

--- a/roles/hugepages/README.md
+++ b/roles/hugepages/README.md
@@ -1,17 +1,17 @@
-Role Name
-=========
+# Role Name
 
-Ansible Role: hugepages 
+Ansible Role: hugepages
 
 Enable Huge Pages on Linux for oracle purposes
 
-For calculation of the hugepages usualy the math goes like this:
+For calculation of the hugepages usually the math goes like this:
 
+```
 X = grep Hugepagesize /proc/meminfo => (the default value is 2048KB = 2MB)
-Y = all client SGAs in MB  =>  (we usualy take 70% of the overall RAM since sometimes we can not plan ahead how much SGA would be required for the database but in any case we usually don't go higher then 70% of the overall RAM )
-Z = #Huge Pages needed = Y / X 
+Y = all client SGAs in MB => (we usually take 70% of the overall RAM since sometimes we can not plan ahead how much SGA would be required for the database but in any case we usually don't go higher then 70% of the overall RAM )
+Z = #Huge Pages needed = Y / X
 
-Also since database SGA size is tightly related with SHMMAX and SHMALL kernel parameters values the ansible hugepages role sets shmmax, shmall, shmmni and hugepages as bundle.  
+Also since database SGA size is tightly related with SHMMAX and SHMALL kernel parameters values the ansible hugepages role sets shmmax, shmall, shmmni and hugepages as bundle.
 
 kernel.shmmax=70% of RAM memory in Bytes
 kernel.shmall= kernel.shmmax / kernel.shmmni
@@ -21,7 +21,7 @@ Also the oracle memlock limit is set to unlimited (both: soft and hard) as per t
 The algorithm used in the ansible hugepages role is the following:
 
 if shmmax is not set in sysctl.conf
-then 
+then
         set shmmax=70% of the RAM
         set shmmni= take the value from memory (usually the default is 4096)
         set shmall=shmmax/shmmni
@@ -29,7 +29,7 @@ then
          reload sysctl
 else
       if shmmax < 70% of the RAM
-      then 
+      then
             set shmmax=70% of the RAM
             set shmmni= take the value from memory (usually the default is 4096)
             set shmall=shmmax/shmmni
@@ -48,44 +48,40 @@ else
                    set shmall=shmmax/shmmni
                    set hugepages=shmmax in MB/Hugepagesize in MB
                    reload sysctl
+```
 
-
-Requirements
-------------
+## Requirements
 
 None.
 
-Role Variables
---------------
+## Role Variables
 
 Available variables are listed below, along with default values (see 'defaults/main.yml'):
 
-   Default value for RAM percentage that we are using for shmmax
+Default value for RAM percentage that we are using for shmmax
 
-   ram_pct_used: 70
+```
+ram_pct_used: 70
+```
 
-
-Dependencies
-------------
+## Dependencies
 
 None.
 
-Example Playbook
-----------------
+## Example Playbook
 
-   - hosts: all
-     become: yes
-     roles:
-       - hugepages
+```yaml
+- hosts: all
+  become: yes
+  roles:
+    - hugepages
+```
 
-
-License
--------
+## License
 
 BSD
 
-Author Information
-------------------
+## Author Information
 
 This role was created by Vladimir Naumovski - Oracle Database Consultant @Pythian
-creation date: 07-2017 
+creation date: 07-2017

--- a/tools/README.md
+++ b/tools/README.md
@@ -31,5 +31,5 @@ Add the following to the appropriate sections of roles/common/defaults/main.yml:
 
 ### Known issues
 
-* Only tested against 12.2, 18c, and 19c patches.
-* No support for multi-file patches.
+- Only tested against 12.2, 18c, and 19c patches.
+- No support for multi-file patches.


### PR DESCRIPTION
## Change Description:

Formatting adjustments (made mostly using the VS Code **Prettier** extension or the **jq** utility) to align with common markdown and JSON Formatting standards.

## Solution Overview:

Removes formatting mistakes and inconsistencies such as, but not limited to:

- Replacing `*` with `-` for bullet lists
- Replace `*` pairs with `_` pairs for italics
- Multiple blank lines
- Trailing white space
- Double spaces before sentences
- Broken code block markers
- JSON formatting and fix technically invalid JSON
- Broken links (such as the "Ansible" and "Oracle Technology Network" links in the `user-guide.md` file)

Spelling and language or grammatical fixes to be part of a separate PR.

## Test Commands:

N/A: No changes to Ansible logic or documentation language made in this PR - only formatting related changes.

## Expected Results:

Files remain readable with minimal changes when viewed through a Markdown viewer (including GitHub's Web interface)
