### PR TITLE
Install perl to support 19c patching if installing into EL

### DIFF
--- a/roles/ora-host/defaults/main.yml
+++ b/roles/ora-host/defaults/main.yml
@@ -62,6 +62,7 @@ oracle_required_rpms:
   - make
   - mpfr
   - nfs-utils
+  - perl # OS perl is required for OJVM patching as per MOS note 2978451.1
   - psmisc
   - quota
   - quota-nls
@@ -180,9 +181,6 @@ oracle_required_rpms_el9:
   - libnsl.i686
   - libnsl2
   - libnsl2.i686
-
-oracle19c_specific_rpms:
-  - perl # OS perl is required for OJVM patching as per MOS note 2978451.1
 
 sysctl_entries:
   - { name: "fs.aio-max-nr", value: "1048576" }

--- a/roles/ora-host/defaults/main.yml
+++ b/roles/ora-host/defaults/main.yml
@@ -181,8 +181,8 @@ oracle_required_rpms_el9:
   - libnsl2
   - libnsl2.i686
 
-oracle19c_specific_rpms_el8:
-  - perl
+oracle19c_specific_rpms:
+  - perl # OS perl is equired for OJVM patching as per MOS note 2978451.1
 
 sysctl_entries:
   - { name: "fs.aio-max-nr", value: "1048576" }

--- a/roles/ora-host/defaults/main.yml
+++ b/roles/ora-host/defaults/main.yml
@@ -125,7 +125,7 @@ oracle_required_rpms_el8:
   - libnsl
   - libnsl.i686
   - libnsl2
-  - libnsl2.i686  
+  - libnsl2.i686
 
 oracle_required_rpms_el9:
   - bc
@@ -179,7 +179,10 @@ oracle_required_rpms_el9:
   - libnsl
   - libnsl.i686
   - libnsl2
-  - libnsl2.i686  
+  - libnsl2.i686
+
+oracle19c_specific_rpms_el8:
+  - perl
 
 sysctl_entries:
   - { name: "fs.aio-max-nr", value: "1048576" }

--- a/roles/ora-host/defaults/main.yml
+++ b/roles/ora-host/defaults/main.yml
@@ -182,7 +182,7 @@ oracle_required_rpms_el9:
   - libnsl2.i686
 
 oracle19c_specific_rpms:
-  - perl # OS perl is equired for OJVM patching as per MOS note 2978451.1
+  - perl # OS perl is required for OJVM patching as per MOS note 2978451.1
 
 sysctl_entries:
   - { name: "fs.aio-max-nr", value: "1048576" }

--- a/roles/ora-host/tasks/main.yml
+++ b/roles/ora-host/tasks/main.yml
@@ -106,7 +106,7 @@
 
 - name: Install Oracle required packages (base/non-rhui config) for RHEL8
   yum:
-    name: "{{ oracle_required_rpms_el8 }}"
+    name: "{{ oracle_required_rpms_el8 + oracle19c_specific_rpms_el8 if (oracle_ver_base | float) >= 19.3 else oracle_required_rpms_el8 }}"
     state: present
     lock_timeout: 180
   when:
@@ -128,7 +128,7 @@
 
 - name: Install Oracle required packages (base/non-rhui config) for OEL8
   yum:
-    name: "{{ oracle_required_rpms_el8 }}"
+    name: "{{ oracle_required_rpms_el8 + oracle19c_specific_rpms_el8 if (oracle_ver_base | float) >= 19.3 else oracle_required_rpms_el8 }}"
     state: present
     lock_timeout: 180
   when:

--- a/roles/ora-host/tasks/main.yml
+++ b/roles/ora-host/tasks/main.yml
@@ -96,7 +96,7 @@
 
 - name: Install Oracle required packages (base/non-rhui config) for OEL7
   yum:
-    name: "{{ oracle_required_rpms + oracle19c_specific_rpms if (oracle_ver_base | float) >= 19.3 else oracle_required_rpms }}"
+    name: "{{ oracle_required_rpms }}"
     state: present
     lock_timeout: 180
   when:
@@ -106,7 +106,7 @@
 
 - name: Install Oracle required packages (base/non-rhui config) for RHEL8
   yum:
-    name: "{{ oracle_required_rpms_el8 + oracle19c_specific_rpms if (oracle_ver_base | float) >= 19.3 else oracle_required_rpms_el8 }}"
+    name: "{{ oracle_required_rpms_el8 }}"
     state: present
     lock_timeout: 180
   when:
@@ -116,7 +116,7 @@
 
 - name: Install Oracle required packages (base/non-rhui config) for RHEL9
   yum:
-    name: "{{ oracle_required_rpms_el9 + oracle19c_specific_rpms if (oracle_ver_base | float) >= 19.3 else oracle_required_rpms_el9 }}"
+    name: "{{ oracle_required_rpms_el9 }}"
     state: present
     lock_timeout: 180
   when:
@@ -128,7 +128,7 @@
 
 - name: Install Oracle required packages (base/non-rhui config) for OEL8
   yum:
-    name: "{{ oracle_required_rpms_el8 + oracle19c_specific_rpms if (oracle_ver_base | float) >= 19.3 else oracle_required_rpms_el8 }}"
+    name: "{{ oracle_required_rpms_el8 }}"
     state: present
     lock_timeout: 180
   when:
@@ -138,7 +138,7 @@
 
 - name: Install Oracle required packages (base/non-rhui config) for OEL9
   yum:
-    name: "{{ oracle_required_rpms_el9 + oracle19c_specific_rpms if (oracle_ver_base | float) >= 19.3 else oracle_required_rpms_el9 }}"
+    name: "{{ oracle_required_rpms_el9 }}"
     state: present
     lock_timeout: 180
   when:
@@ -150,7 +150,7 @@
 
 - name: Install Oracle required packages (rhui config)
   yum:
-    name: "{{ oracle_required_rpms + oracle19c_specific_rpms if (oracle_ver_base | float) >= 19.3 else oracle_required_rpms }}"
+    name: "{{ oracle_required_rpms }}"
     state: present
     lock_timeout: 180
     enablerepo: rhui-rhel-7-server-rhui-optional-rpms

--- a/roles/ora-host/tasks/main.yml
+++ b/roles/ora-host/tasks/main.yml
@@ -96,7 +96,7 @@
 
 - name: Install Oracle required packages (base/non-rhui config) for OEL7
   yum:
-    name: "{{ oracle_required_rpms }}"
+    name: "{{ oracle_required_rpms + oracle19c_specific_rpms if (oracle_ver_base | float) >= 19.3 else oracle_required_rpms }}"
     state: present
     lock_timeout: 180
   when:
@@ -106,7 +106,7 @@
 
 - name: Install Oracle required packages (base/non-rhui config) for RHEL8
   yum:
-    name: "{{ oracle_required_rpms_el8 + oracle19c_specific_rpms_el8 if (oracle_ver_base | float) >= 19.3 else oracle_required_rpms_el8 }}"
+    name: "{{ oracle_required_rpms_el8 + oracle19c_specific_rpms if (oracle_ver_base | float) >= 19.3 else oracle_required_rpms_el8 }}"
     state: present
     lock_timeout: 180
   when:
@@ -116,7 +116,7 @@
 
 - name: Install Oracle required packages (base/non-rhui config) for RHEL9
   yum:
-    name: "{{ oracle_required_rpms_el9 }}"
+    name: "{{ oracle_required_rpms_el9 + oracle19c_specific_rpms if (oracle_ver_base | float) >= 19.3 else oracle_required_rpms_el9 }}"
     state: present
     lock_timeout: 180
   when:
@@ -128,7 +128,7 @@
 
 - name: Install Oracle required packages (base/non-rhui config) for OEL8
   yum:
-    name: "{{ oracle_required_rpms_el8 + oracle19c_specific_rpms_el8 if (oracle_ver_base | float) >= 19.3 else oracle_required_rpms_el8 }}"
+    name: "{{ oracle_required_rpms_el8 + oracle19c_specific_rpms if (oracle_ver_base | float) >= 19.3 else oracle_required_rpms_el8 }}"
     state: present
     lock_timeout: 180
   when:
@@ -138,7 +138,7 @@
 
 - name: Install Oracle required packages (base/non-rhui config) for OEL9
   yum:
-    name: "{{ oracle_required_rpms_el9 }}"
+    name: "{{ oracle_required_rpms_el9 + oracle19c_specific_rpms if (oracle_ver_base | float) >= 19.3 else oracle_required_rpms_el9 }}"
     state: present
     lock_timeout: 180
   when:
@@ -150,7 +150,7 @@
 
 - name: Install Oracle required packages (rhui config)
   yum:
-    name: "{{ oracle_required_rpms }}"
+    name: "{{ oracle_required_rpms + oracle19c_specific_rpms if (oracle_ver_base | float) >= 19.3 else oracle_required_rpms }}"
     state: present
     lock_timeout: 180
     enablerepo: rhui-rhel-7-server-rhui-optional-rpms


### PR DESCRIPTION
## Change Description:

When required, install OS perl to avoid RU patching error `make: *** [ins_rdbms.mk:573: javavm_refresh] Error 127`.

## Solution Overview:

In the `TASK [patch : (RDBMS) Apply patch]` task section, the `TASK [patch : opatch_apply | Run opatch apply]` task from file `roles/patch/tasks/opatch_apply.yml` fails when applying the RU patch to a 19c database home with the error:

```
OPatch failed to restore OH '/u01/app/oracle/product/19.3.0/dbhome_1'. Consult OPatch document to restore the home manually before proceeding.
UtilSession failed: Re-link fails on target "javavm_refresh"., stderr_lines: [OPatch failed to restore OH '/u01/app/oracle/product/19.3.0/dbhome_1'. Consult OPatch document to restore the home manually before proceeding., UtilSession failed: Re-link fails on target "javavm_refresh".], stdout: Oracle Interim Patch Installer version 12.2.0.1.44
Copyright (c) 2025, Oracle Corporation.  All rights reserved.


Oracle Home       : /u01/app/oracle/product/19.3.0/dbhome_1
Central Inventory : /u01/app/oraInventory
   from           : /u01/app/oracle/product/19.3.0/dbhome_1/oraInst.loc
OPatch version    : 12.2.0.1.44
OUI version       : 12.2.0.7.0
Log file location : /u01/app/oracle/product/19.3.0/dbhome_1/cfgtoollogs/opatch/opatch2025-01-18_12-36-53PM_1.log

Verifying environment and performing prerequisite checks...
OPatch continues with these patches:   36199232

Do you want to proceed? [y|n]
Y (auto-answered by -silent)
User Responded with: Y
All checks passed.

Please shutdown Oracle instances running out of this ORACLE_HOME on the local system.
(Oracle Home = '/u01/app/oracle/product/19.3.0/dbhome_1')


Is the local system ready for patching? [y|n]
Y (auto-answered by -silent)
User Responded with: Y
Backing up files...
Applying interim patch '36199232' to OH '/u01/app/oracle/product/19.3.0/dbhome_1'

Patching component oracle.javavm.server, 19.0.0.0.0...

Patching component oracle.javavm.server.core, 19.0.0.0.0...

Patching component oracle.rdbms.dbscripts, 19.0.0.0.0...

Patching component oracle.rdbms, 19.0.0.0.0...

Patching component oracle.javavm.client, 19.0.0.0.0...
Make failed to invoke "/usr/bin/make -f ins_rdbms.mk javavm_refresh ORACLE_HOME=/u01/app/oracle/product/19.3.0/dbhome_1 OPATCH_SESSION=apply"....'make: perl: Command not found
make: *** [ins_rdbms.mk:573: javavm_refresh] Error 127
'

The following make actions have failed :

Re-link fails on target "javavm_refresh".


Do you want to proceed? [y|n]
N (auto-answered by -silent)
User Responded with: N

Restoring "/u01/app/oracle/product/19.3.0/dbhome_1" to the state prior to running NApply...

NApply was not able to restore the home.  Please invoke the following scripts:
  - restore.[sh,bat]
  - make.txt (Unix only)
to restore the ORACLE_HOME.  They are located under
"/u01/app/oracle/product/19.3.0/dbhome_1/.patch_storage/NApply/2025-01-18_12-36-53PM"

Log file location: /u01/app/oracle/product/19.3.0/dbhome_1/cfgtoollogs/opatch/opatch2025-01-18_12-36-53PM_1.log

OPatch failed with error code 73, stdout_lines: ... , OPatch failed with error code 73
```

> NOTE: Problem has likely not been encountered/reported recently due to typo in the `gi_patches` array value for the **19.23.0.0.240416** `RU_Combo` patch where the release accidentally has `01` for the month (copied from the previous line) instead of correctly having `04` for the month in the `release` element. Consequently, the `RU_Combo` patch is not found, not applied, and the error is not encountered. After correcting this typo, an attempt is made to apply the patch and the error is encountered.
>
> Check that typo has been corrected (two lines should be returned if corrected):
>
> ```bash
> $ grep "19.23.0.0.240416" roles/common/defaults/main.yml
>  - { category: "RU", base: "19.3.0.0.0", release: "19.23.0.0.240416", patchnum: "36209493", patchfile: "p36209493_190000_Linux-x86-64.zip", patch_subdir: "/36233126", prereq_check: FALSE, method: "opatchauto apply", ocm: FALSE, upgrade: FALSE, md5sum: "CTM7Xpq2rSWtetdERsi4IQ==" }
>  - { category: "RU_Combo", base: "19.3.0.0.0", release: "19.23.0.0.240416", patchnum: "36209493", patchfile: "p36209493_190000_Linux-x86-64.zip", patch_subdir: "/36199232", prereq_check: TRUE, method: "opatch apply", ocm: FALSE, upgrade: TRUE, md5sum: "CTM7Xpq2rSWtetdERsi4IQ==" }
> ```

The root cause of the error causing the patch application to fail is fully described in MOS document: [OPatch apply for OJVM RU fails with "make: perl: Command not found make: \*\*\* [ins_rdbms.mk:573: javavm_refresh] Error 127" (Doc ID 2978451.1) ](https://support.oracle.com/epmos/faces/DocContentDisplay?id=2978451.1)

However, perl is not listed as a required dependency in the Oracle 19c Linux installation guide: [Supported Oracle Linux 8 Distributions for x86-64](https://docs.oracle.com/en/database/oracle/oracle-database/19/ladbi/supported-oracle-linux-8-distributions-for-x86-64.html).

After installing OS perl (as per the guidance from the MOS document), patching succeeds:

```
TASK [patch : opatch_apply | opatch apply results] *****************************
ok: [10.2.80.95] => {
    "msg": {
        "changed": true,
        "cmd": [
            "/u01/app/oracle/product/19.3.0/dbhome_1/OPatch/opatch",
            "apply",
            "-silent"
        ],
        "delta": "0:01:38.143220",
        "end": "2025-01-18 14:16:12.392547",
        "failed": false,
        "failed_when_result": false,
        "msg": "",
        "rc": 0,
        "start": "2025-01-18 14:14:34.249327",
        "stderr": "",
        "stderr_lines": [],
        "stdout": "Oracle Interim Patch Installer version 12.2.0.1.44\nCopyright (c) 2025, Oracle Corporation.  All rights reserved.\n\n\nOracle Home       : ...
        "stdout_lines": [
...
            "Patch 36199232 successfully applied.",
            "Log file location: /u01/app/oracle/product/19.3.0/dbhome_1/cfgtoollogs/opatch/opatch2025-01-18_14-14-34PM_1.log",
            "",
            "OPatch succeeded."
        ]
    }
}
```

This change only installs OS perl if base Oracle release is >= 19.3 (as per MOS document)

## Test Commands:

### Test Prep:

Update the file `roles/common/defaults/main.yml` changing the string `240116` --> `240416` for patch number `36209493` on the very last line of the file.

Verify that change has been properly made using `grep "19.23.0.0.240416" roles/common/defaults/main.yml` --> should return two lines as shown above.

Sample `asm_disk_config.json` file content:

```json
[
  {
    "diskgroup": "DATA",
    "disks": [
      {
        "blk_device": "/dev/disk/by-id/google-oracle-asm-1",
        "name": "DATA1"
      }
    ]
  },
  {
    "diskgroup": "RECO",
    "disks": [
      {
        "blk_device": "/dev/disk/by-id/google-oracle-asm-2",
        "name": "RECO1"
      }
    ]
  }
]
```

Sample `data_mounts_config.json` file content:

```json
[
  {
    "purpose": "software",
    "blk_device": "/dev/disk/by-id/google-oracle-disk-1",
    "name": "u01",
    "fstype": "xfs",
    "mount_point": "/u01",
    "mount_opts": "nofail"
  },
  {
    "purpose": "diag",
    "blk_device": "/dev/disk/by-id/google-oracle-disk-2",
    "name": "u02",
    "fstype": "xfs",
    "mount_point": "/u02",
    "mount_opts": "nofail"
  }
]
```

### Test: Create a 19c database without patches, then manually patch:

Enter the appropriate IP address for the target database server that will be patched to release **19.23**:

```bash
export INSTANCE_IP_ADDR=10.2.80.56
```

Run the `install-oracle.sh` script (first verifying via `ssh` that Perl is not installed on the target) with the `--no-patch` option and manually patch using the latest RU patch set using the `apply-patch.sh` script:

```bash
ssh ${INSTANCE_SSH_USER:-`whoami`}@${INSTANCE_IP_ADDR} perl -V

grep "19.23.0.0.240416" roles/common/defaults/main.yml

./install-oracle.sh \
  --instance-ip-addr ${INSTANCE_IP_ADDR} \
  --ora-version 19 \
  --ora-swlib-bucket gs://pythian-gto-oracle-software/19c \
  --backup-dest "+RECO" \
  --no-patch \
  --allow-install-on-vm

./apply-patch.sh \
  --inventory-file inventory_files/inventory_${INSTANCE_IP_ADDR}_ORCL \
  --ora-version 19 \
  --ora-release 19.23.0.0.240416 \
  --ora-swlib-bucket gs://pythian-gto-oracle-software/19c \
  --ora-swlib-path /u02/oracle_install \
  --ora-staging /u02/oracle_install
```

## Expected Results:

After running with change:

1. The `./apply-patch.sh` step (and Ansible playbook) completes successfully.
1. Both the RDBMS and GI homes show that the **19.23** RU has been applied: verify using `opatch lspatches`.
1. The ORCL database shows that the **19.23** patch has been applied: check the contents of view `dba_registry_sqlpatch`.
