### PR TITLE
Add support for the latest RU patches (up to and including JAN2025).

### DIFF
--- a/docs/patch-metadata.md
+++ b/docs/patch-metadata.md
@@ -1,8 +1,8 @@
-#### A note on patch metadata
+# A note on patch metadata
 
-The patching code derives the patch metadata from the following blocks in the file role/common/default/main.yml:
+The patching code derives the patch metadata from the following blocks in the file `role/common/default/main.yml`:
 
-```
+```yaml
 gi_patches:
 ...
 - { category: "RU", base: "19.3.0.0.0", release: "19.9.0.0.201020", patchnum: "31720429", patchfile: "p31720429_190000_Linux-x86-64.zip", patch_subdir: "/31750108", prereq_check: FALSE, method: "opatchauto apply", ocm: FALSE, upgrade: FALSE, md5sum: "tTZDYSasdnt7lrNJ/MYm1g==" }
@@ -14,15 +14,15 @@ rdbms_patches:
 ```
 
 These metadata numbers can be taken from consulting appropriate MOS Notes, such as:
-
-- Master Note for Database Proactive Patch Program (Doc ID 888.1)
-- Oracle Database 19c Proactive Patch Information (Doc ID 2521164.1)
-- Database 18c Proactive Patch Information (Doc ID 2369376.1)
-- Database 12.2.0.1 Proactive Patch Information (Doc ID 2285557.1)
+- [Assistant: Download Reference for Oracle Database/GI Update, Revision, PSU, SPU(CPU), Bundle Patches, Patchsets and Base Releases (Doc ID 2118136.2)](https://support.oracle.com/epmos/faces/DocContentDisplay?id=2118136.2)
+- [Master Note for Database Proactive Patch Program (Doc ID 888.1)](https://support.oracle.com/epmos/faces/DocContentDisplay?id=888.1)
+- [Oracle Database 19c Proactive Patch Information (Doc ID 2521164.1)](https://support.oracle.com/epmos/faces/DocContentDisplay?id=2521164.1)
+- [Database 18c Proactive Patch Information (Doc ID 2369376.1)](https://support.oracle.com/epmos/faces/DocContentDisplay?id=2369376.1)
+- [Database 12.2.0.1 Proactive Patch Information (Doc ID 2285557.1)](https://support.oracle.com/epmos/faces/DocContentDisplay?id=2285557.1)
 
 The md5sum can be determined by listing the file once in a GCS bucket:
 
-```
+```bash
 $ gsutil ls -L gs://example-bucket/p32578973_190000_Linux-x86-64.zip | grep md5
     Hash (md5):             YLEOruyjCOdDvUOMBUazNQ==
 ```
@@ -50,5 +50,4 @@ Bearing in mind that the GI RU's patch zipfile contains the patch molecules that
 └── PatchSearch.xml
 
 ```
-
-Accordingly the patch_subdir values can be edited, as noted in the foregoing.
+Accordingly the `patch_subdir` values can be edited, as noted in the foregoing.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -6,52 +6,55 @@ published: True
 
 ## Table of Contents
 
-- [Command quick reference for single instance deployments](#command-quick-reference-for-single-instance-deployments)
-- [Command quick reference for RAC deployments](#command-quick-reference-for-rac-deployments)
-- [Command quick reference for DR deployments](#command-quick-reference-for-dr-deployments)
-- [Overview](#overview)
-  - [Software Stack](#software-stack)
-  - [Requirements and Prerequisites](#requirements-and-prerequisites)
-    - [Control node requirements](#control-node-requirements)
-    - [Target server requirements](#target-server-requirements)
-- [Installing the toolkit](#installing-the-toolkit)
-- [Downloading and staging the Oracle Software](#downloading-and-staging-the-oracle-software)
-  - [Downloading the Oracle installation software](#downloading-the-oracle-installation-software)
-    - [Downloading Patches from My Oracle Support](#downloading-patches-from-my-oracle-support)
-    - [Required Oracle Software - Download Summary](#required-oracle-software---download-summary)
-  - [Staging the Oracle installation media](#staging-the-oracle-installation-media)
-    - [Cloud Storage bucket](#cloud-storage-bucket)
-    - [Cloud Storage FUSE](#cloud-storage-fuse)
-    - [NFS share](#nfs-share)
-  - [Validating Media](#validating-media)
-- [Prerequisite configuration](#prerequisite-configuration)
-  - [Data mount configuration file](#data-mount-configuration-file)
-  - [ASM disk group configuration file](#asm-disk-group-configuration-file)
-  - [Specifying LVM logical volumes](#specifying-lvm-logical-volumes)
-- [Configuring Installations](#configuring-installations)
-  - [Configuration defaults](#configuration-defaults)
-  - [Oracle User Directories](#oracle-user-directories)
-  - [Database backup configuration](#database-backup-configuration)
-  - [Parameters](#parameters)
-    - [Target environment parameters](#target-environment-parameters)
-    - [Software installation parameters](#software-installation-parameters)
-    - [Storage configuration parameters](#storage-configuration-parameters)
-    - [Database configuration parameters](#database-configuration-parameters)
-    - [RAC configuration parameters](#rac-configuration-parameters)
-    - [Backup configuration parameters](#backup-configuration-parameters)
-    - [Additional operational parameters](#additional-operational-parameters)
-  - [Example Toolkit Execution](#example-toolkit-execution)
-- [Post installation tasks](#post-installation-tasks)
-  - [Reset passwords](#reset-passwords)
-  - [Validate the environment](#validate-the-environment)
-    - [Listing Oracle ASM devices](#listing-oracle-asm-devices)
-    - [Displaying cluster resource status](#displaying-cluster-resource-status)
-    - [Verify an Oracle cluster](#verify-an-oracle-cluster)
-    - [Oracle validation utilities](#oracle-validation-utilities)
-  - [Patching](#patching)
-    - [A note on patch metadata](#a-note-on-patch-metadata)
-  - [Patching RAC databases](#patching-rac-databases)
-  - [Destructive Cleanup](#destructive-cleanup)
+- [Toolkit for Bare Metal Solution: User Guide](#toolkit-for-bare-metal-solution-user-guide)
+  - [Table of Contents](#table-of-contents)
+  - [Command quick reference for single instance deployments](#command-quick-reference-for-single-instance-deployments)
+  - [Command quick reference for RAC deployments](#command-quick-reference-for-rac-deployments)
+  - [Command quick reference for DR deployments](#command-quick-reference-for-dr-deployments)
+  - [Overview](#overview)
+    - [Software Stack](#software-stack)
+    - [Requirements and Prerequisites](#requirements-and-prerequisites)
+      - [Control node requirements](#control-node-requirements)
+      - [Target server requirements](#target-server-requirements)
+  - [Installing the toolkit](#installing-the-toolkit)
+  - [Downloading and staging the Oracle Software](#downloading-and-staging-the-oracle-software)
+    - [Downloading the Oracle installation software](#downloading-the-oracle-installation-software)
+      - [Downloading Patches from My Oracle Support](#downloading-patches-from-my-oracle-support)
+      - [Required Oracle Software - Download Summary](#required-oracle-software---download-summary)
+    - [Staging the Oracle installation media](#staging-the-oracle-installation-media)
+      - [Cloud Storage bucket](#cloud-storage-bucket)
+      - [Cloud Storage FUSE](#cloud-storage-fuse)
+      - [NFS share](#nfs-share)
+    - [Validating Media](#validating-media)
+  - [Prerequisite configuration](#prerequisite-configuration)
+    - [Data mount configuration file](#data-mount-configuration-file)
+    - [ASM disk group configuration file](#asm-disk-group-configuration-file)
+    - [Specifying LVM logical volumes](#specifying-lvm-logical-volumes)
+  - [Configuring Installations](#configuring-installations)
+    - [Configuration defaults](#configuration-defaults)
+    - [Oracle User Directories](#oracle-user-directories)
+    - [Database backup configuration](#database-backup-configuration)
+    - [Parameters](#parameters)
+      - [Target environment parameters](#target-environment-parameters)
+      - [Software installation parameters](#software-installation-parameters)
+      - [Storage configuration parameters](#storage-configuration-parameters)
+      - [Database configuration parameters](#database-configuration-parameters)
+      - [RAC configuration parameters](#rac-configuration-parameters)
+      - [Backup configuration parameters](#backup-configuration-parameters)
+      - [Additional operational parameters](#additional-operational-parameters)
+    - [Example Toolkit Execution](#example-toolkit-execution)
+  - [Post installation tasks](#post-installation-tasks)
+    - [Reset passwords](#reset-passwords)
+    - [Validate the environment](#validate-the-environment)
+      - [Listing Oracle ASM devices](#listing-oracle-asm-devices)
+      - [Displaying cluster resource status](#displaying-cluster-resource-status)
+      - [Verify an Oracle cluster](#verify-an-oracle-cluster)
+      - [Oracle validation utilities](#oracle-validation-utilities)
+    - [Patching](#patching)
+      - [A note on patch metadata](#a-note-on-patch-metadata)
+    - [Patching RAC databases](#patching-rac-databases)
+      - [BMS RAC install with latest RU](#bms-rac-install-with-latest-ru)
+    - [Destructive Cleanup](#destructive-cleanup)
 
 ## Command quick reference for single instance deployments
 
@@ -358,6 +361,24 @@ Support")</th>
 <tr>
 <td></td>
 <td>Patch - MOS</TD>
+<TD>COMBO OF OJVM RU COMPONENT 19.26.0.0.250100 + GI RU 19.26.0.0.250100</td>
+<td>p00000000_190000_Linux-x86-64.zip</td>
+</tr>
+<tr>
+<td></td>
+<td>Patch - MOS</TD>
+<TD>COMBO OF OJVM RU COMPONENT 19.25.0.0.241015 + GI RU 19.25.0.0.241015</td>
+<td>p36866740_190000_Linux-x86-64.zip</td>
+</tr>
+<tr>
+<td></td>
+<td>Patch - MOS</TD>
+<TD>COMBO OF OJVM RU COMPONENT 19.24.0.0.240716 + GI RU 19.24.0.0.240716</td>
+<td>p36522439_190000_Linux-x86-64.zip</td>
+</tr>
+<tr>
+<td></td>
+<td>Patch - MOS</TD>
 <TD>COMBO OF OJVM RU COMPONENT 19.23.0.0.240416 + GI RU 19.23.0.0.240416</td>
 <td>p36209493_190000_Linux-x86-64.zip</td>
 </tr>
@@ -391,7 +412,6 @@ Support")</th>
 <td>COMBO OF OJVM RU COMPONENT 19.10.0.0.210119 + GI RU 19.10.0.0.210119</td>
 <td>p32126842_190000_Linux-x86-64.zip</td>
 </tr>
-
 <tr>
 <td></td>
 <td></td>
@@ -459,7 +479,6 @@ href="https://support.oracle.com/epmos/faces/PatchResultsNDetails?releaseId=6000
 <td>COMBO OF OJVM RU COMPONENT 18.13.0.0.210119 + GI RU 18.13.0.0.210119</td>
 <td>p32126862_180000_Linux-x86-64.zip</td>
 </tr>
-
 <tr>
 <td></td>
 <td></td>
@@ -521,6 +540,12 @@ href="https://support.oracle.com/epmos/faces/PatchResultsNDetails?releaseId=6000
 <td>Oracle Grid Infrastructure 12.2.0.1.0 for Linux x86-64 for Linux
 x86-64</td>
 <td>V840012-01.zip</td>
+</tr>
+<tr>
+<td></td>
+<td>Patch - MOS</td>
+<td>COMBO OF OJVM RU COMPONENT 12.2.0.1.220118 + 12.2.0.1.220118 GIJAN2022RU</td>
+<td>p33559966_122010_Linux-x86-64.zip</td>
 </tr>
 <tr>
 <td></td>
@@ -619,6 +644,24 @@ V77388-01_2of2.zip</td>
 <td>Oracle Grid Infrastructure 12.1.0.2.0 for Linux x86-64</td>
 <td>V46096-01_1of2.zip<br>
 V46096-01_2of2.zip</td>
+</tr>
+<tr>
+<td></td>
+<td>Patch - MOS</td>
+<td>COMBO OF OJVM COMPONENT 12.1.0.2.220719 DB PSU + GIPSU 12.1.0.2.220719</td>
+<td>p34163645_121020_Linux-x86-64.zip</td>
+</tr>
+<tr>
+<td></td>
+<td>Patch - MOS</td>
+<td>COMBO OF OJVM COMPONENT 12.1.0.2.220419 DB PSU + GIPSU 12.1.0.2.220419</td>
+<td>p33859511_121020_Linux-x86-64.zip</td>
+</tr>
+<tr>
+<td></td>
+<td>Patch - MOS</td>
+<td>COMBO OF OJVM COMPONENT 12.1.0.2.220118 DB PSU + GIPSU 12.1.0.2.220118</td>
+<td>p33560011_121020_Linux-x86-64.zip</td>
 </tr>
 <tr>
 <td></td>
@@ -2150,10 +2193,10 @@ both the Grid Infrastructure and Database homes by using the
 
 By default, `install-oracle.sh` updates to the latest available patch. To
 apply a specific patch instead, use the `--no-patch` option in `install-oracle.sh`
-to skip patching at installation time. After installation is complete, execute
-`apply-patch.sh` with the `--ora-release` option. Specify the full release name including
-timestamp; a list of release names is available in
-https://github.com/google/bms-toolkit/tree/master/roles/common/defaults/main.yml
+to skip patching at installation time.  After installation is complete,  execute
+`apply-patch.sh` with the `--ora-release` option.  Specify the full release name including
+timestamp;  a list of release names is available in [roles/common/defaults/main.yml](
+https://github.com/google/bms-toolkit/tree/master/roles/common/defaults/main.yml)
 under `gi-patches` and `rdbms-patches`.
 
 A digest of the required patch files, including checksum hashes is provided in
@@ -2184,13 +2227,13 @@ $ ./apply-patch.sh \
   --ora-swlib-path /u02/oracle_install \
   --ora-staging /u02/oracle_install \
   --ora-version 19.3.0.0.0 \
-  --ora-release 19.6.0.0.200114 \
+  --ora-release 19.25.0.0.241015 \
     --inventory-file inventory_files/inventory_toolkit-db2_ORCL
 
 Running with parameters from command line or environment variables:
 
 ORA_DB_NAME=ORCL
-ORA_RELEASE=19.6.0.0.200114
+ORA_RELEASE=19.25.0.0.241015
 ORA_STAGING=/u02/oracle_install
 ORA_SWLIB_BUCKET=gs://oracle-software
 ORA_SWLIB_PATH=/u02/oracle_install
@@ -2218,7 +2261,7 @@ TASK [patch : Update OPatch in GRID_HOME]
 
 #### A note on patch metadata
 
-See [patching-metadata.md](./patching-metadata.md) for details on
+See [patch-metadata.md](./patch-metadata.md) for details on
 updating quarterly Release Update metadata.
 
 ### Patching RAC databases

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -314,6 +314,9 @@ gi_patches:
   - { category: "RU", base: "19.3.0.0.0", release: "19.21.0.0.231017", patchnum: "35742441", patchfile: "p35742441_190000_Linux-x86-64.zip", patch_subdir: "/35642822", prereq_check: FALSE, method: "opatchauto apply", ocm: FALSE, upgrade: FALSE, md5sum: "XCHpxqMlJ0/4dTUeMYNcSg==" }
   - { category: "RU", base: "19.3.0.0.0", release: "19.22.0.0.240116", patchnum: "36031453", patchfile: "p36031453_190000_Linux-x86-64.zip", patch_subdir: "/35940989", prereq_check: FALSE, method: "opatchauto apply", ocm: FALSE, upgrade: FALSE, md5sum: "HEUyMq/Zdugnxn76ebihgA==" }
   - { category: "RU", base: "19.3.0.0.0", release: "19.23.0.0.240416", patchnum: "36209493", patchfile: "p36209493_190000_Linux-x86-64.zip", patch_subdir: "/36233126", prereq_check: FALSE, method: "opatchauto apply", ocm: FALSE, upgrade: FALSE, md5sum: "CTM7Xpq2rSWtetdERsi4IQ==" }
+  - { category: "RU", base: "19.3.0.0.0", release: "19.24.0.0.240716", patchnum: "36522439", patchfile: "p36522439_190000_Linux-x86-64.zip", patch_subdir: "/36582629", prereq_check: FALSE, method: "opatchauto apply", ocm: FALSE, upgrade: FALSE, md5sum: "ysQplJ/kY19rRPZmntFsMA==" }
+  - { category: "RU", base: "19.3.0.0.0", release: "19.25.0.0.241015", patchnum: "36866740", patchfile: "p36866740_190000_Linux-x86-64.zip", patch_subdir: "/36916690", prereq_check: FALSE, method: "opatchauto apply", ocm: FALSE, upgrade: FALSE, md5sum: "f8DKaIiP7v811/WaRyacTQ==" }
+  - { category: "RU", base: "19.3.0.0.0", release: "19.26.0.0.250121", patchnum: "37262208", patchfile: "p37262208_190000_Linux-x86-64.zip", patch_subdir: "/37257886", prereq_check: FALSE, method: "opatchauto apply", ocm: FALSE, upgrade: FALSE, md5sum: "zqZeJ3/ujDWcLr+reZOHpw==" }
 
 rdbms_patches:
 # 11.2.0.4 OJVM packages from Combo
@@ -379,4 +382,6 @@ rdbms_patches:
   - { category: "RU_Combo", base: "19.3.0.0.0", release: "19.21.0.0.231017", patchnum: "35742441", patchfile: "p35742441_190000_Linux-x86-64.zip", patch_subdir: "/35648110", prereq_check: TRUE, method: "opatch apply", ocm: FALSE, upgrade: TRUE, md5sum: "XCHpxqMlJ0/4dTUeMYNcSg==" }
   - { category: "RU_Combo", base: "19.3.0.0.0", release: "19.22.0.0.240116", patchnum: "36031453", patchfile: "p36031453_190000_Linux-x86-64.zip", patch_subdir: "/35926646", prereq_check: TRUE, method: "opatch apply", ocm: FALSE, upgrade: TRUE, md5sum: "HEUyMq/Zdugnxn76ebihgA==" }
   - { category: "RU_Combo", base: "19.3.0.0.0", release: "19.23.0.0.240416", patchnum: "36209493", patchfile: "p36209493_190000_Linux-x86-64.zip", patch_subdir: "/36199232", prereq_check: TRUE, method: "opatch apply", ocm: FALSE, upgrade: TRUE, md5sum: "CTM7Xpq2rSWtetdERsi4IQ==" }
-
+  - { category: "RU_Combo", base: "19.3.0.0.0", release: "19.24.0.0.240716", patchnum: "36522439", patchfile: "p36522439_190000_Linux-x86-64.zip", patch_subdir: "/36414915", prereq_check: TRUE, method: "opatch apply", ocm: FALSE, upgrade: TRUE, md5sum: "ysQplJ/kY19rRPZmntFsMA==" }
+  - { category: "RU_Combo", base: "19.3.0.0.0", release: "19.25.0.0.241015", patchnum: "36866740", patchfile: "p36866740_190000_Linux-x86-64.zip", patch_subdir: "/36878697", prereq_check: TRUE, method: "opatch apply", ocm: FALSE, upgrade: TRUE, md5sum: "f8DKaIiP7v811/WaRyacTQ==" }
+  - { category: "RU_Combo", base: "19.3.0.0.0", release: "19.26.0.0.250121", patchnum: "37262208", patchfile: "p37262208_190000_Linux-x86-64.zip", patch_subdir: "/37102264", prereq_check: TRUE, method: "opatch apply", ocm: FALSE, upgrade: TRUE, md5sum: "zqZeJ3/ujDWcLr+reZOHpw==" }


### PR DESCRIPTION
## Change Description:

Add support for the latest RU patches (up to JAN2025).

## Solution Overview:

For Oracle 19c three new quarterly RU patches have been released since the last toolkit update:

Therefore, for Oracle 19c, need to validate the patching of:

| Patch Description          | Patch Number | Patch File                        |
| -------------------------- | ------------ | --------------------------------- |
| JUL2024 (19.24.0.0.240716) | 36522439     | p36522439_190000_Linux-x86-64.zip |
| OCT2024 (19.25.0.0.241015) | 36866740     | p36866740_190000_Linux-x86-64.zip |
| JAN2025 (19.26.0.0.250121) | 37262208     | p37262208_190000_Linux-x86-64.zip |

Also update documentation (Markdown file only) for one 12cR2 and three 12cR1 RU patches that are in the toolkit but are missing from the documentation.

## Test Commands:

> **IMPORTANT:** Ensure target server has at least 6GB of swap

### Test Prep:

Required `asm_disk_config.json` file content:

```json
[
  {
    "diskgroup": "DATA",
    "disks": [
      {
        "blk_device": "/dev/disk/by-id/google-oracle-asm-1",
        "name": "DATA1"
      }
    ]
  },
  {
    "diskgroup": "RECO",
    "disks": [
      {
        "blk_device": "/dev/disk/by-id/google-oracle-asm-2",
        "name": "RECO1"
      }
    ]
  }
]
```

Required `data_mounts_config.json` file content:

```json
[
  {
    "purpose": "software",
    "blk_device": "/dev/disk/by-id/google-oracle-disk-1",
    "name": "u01",
    "fstype": "xfs",
    "mount_point": "/u01",
    "mount_opts": "nofail"
  },
  {
    "purpose": "diag",
    "blk_device": "/dev/disk/by-id/google-oracle-disk-2",
    "name": "u02",
    "fstype": "xfs",
    "mount_point": "/u02",
    "mount_opts": "nofail"
  }
]
```

Enter the appropriate IP address for the target database server:

```bash
export INSTANCE_IP_ADDR=10.2.80.85
```

Install 19c EE without applying any patches (using the `--no-patch` option):

```bash
./install-oracle.sh \
  --instance-ip-addr ${INSTANCE_IP_ADDR} \
  --instance-hostname db-server19c \
  --ora-edition EE \
  --ora-version 19.3.0.0.0 \
  --ora-swlib-bucket gs://pythian-gto-oracle-software/19c \
  --backup-dest "+RECO" \
  --allow-install-on-vm
```

### Test 1: Apply new 19.24 patch:

Enter the appropriate IP address for the target database server that will be patched to `19.24`:

```bash
export INSTANCE_IP_ADDR=10.2.80.85
```

Apply the `19.24` patch set to both the GI and RDBMS homes:

```bash
./apply-patch.sh \
  --inventory-file inventory_files/inventory_${INSTANCE_IP_ADDR}_ORCL \
  --ora-version 19 \
  --ora-release 19.24.0.0.240716 \
  --ora-swlib-bucket gs://pythian-gto-oracle-software/19c \
  --ora-swlib-path /u02/oracle_install \
  --ora-staging /u02/oracle_install
```

### Test 2: Apply new 19.25 patch:

Enter the appropriate IP address for the target database server that will be patched to `19.25`:

```bash
export INSTANCE_IP_ADDR=10.2.80.85
```

Apply the `19.25` patch set to both the GI and RDBMS homes:

```bash
./apply-patch.sh \
  --inventory-file inventory_files/inventory_${INSTANCE_IP_ADDR}_ORCL \
  --ora-version 19 \
  --ora-release 19.25.0.0.241015 \
  --ora-swlib-bucket gs://pythian-gto-oracle-software/19c \
  --ora-swlib-path /u02/oracle_install \
  --ora-staging /u02/oracle_install
```

### Test 3: Apply new 19.26 patch:

Enter the appropriate IP address for the target database server that will be patched to `19.26`:

```bash
export INSTANCE_IP_ADDR=10.2.80.85
```

Apply the `19.26` patch set to both the GI and RDBMS homes:

```bash
./apply-patch.sh \
  --inventory-file inventory_files/inventory_${INSTANCE_IP_ADDR}_ORCL \
  --ora-version 19 \
  --ora-release 19.26.0.0.250100 \
  --ora-swlib-bucket gs://pythian-gto-oracle-software/19c \
  --ora-swlib-path /u02/oracle_install \
  --ora-staging /u02/oracle_install
```

## Expected Results:

Check that the RDBMS Oracle Home has been properly patched. As the `oracle` user run:

```bash
${ORACLE_HOME}/OPatch/opatch lsinventory -patch | grep -i 'Release Update'
```

Verify that the database is patched to the correct release. Verification command:

```bash
sqlplus -s -L / as sysdba <<EOF
COL VERSION FORMAT A20
COL ACTION_TIME FORMAT A40
SELECT patch_type, TRIM(REGEXP_SUBSTR(description,' \d{2}\.([^\s]+) ')) version, action_time
  FROM dba_registry_sqlpatch s
 WHERE patch_type IN ('RU','RUI','RUR','CU') AND  status = 'SUCCESS'
 ORDER BY action_time DESC;
EOF
```

Check that the Grid Infrastructure Home has been properly patched. As the `grid` user run:

```bash
${GRID_HOME}/OPatch/opatch lsinventory -patch | grep -i 'Release Update'
```

As a small bonus verification, check the version of the `asmcmd` utility and ensure that it matches the patch version:

```bash
asmcmd -V
```
