### PR TITLE
Removed /u02 mountpoint from default configuration and validated

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -86,7 +86,7 @@ options, and usage scenarios. All commands run from the "control node".
    ./install-oracle.sh \
    --ora-swlib-bucket gs://[cloud-storage-bucket-name] \
    --backup-dest "+RECO" \
-   --ora-swlib-path /u02/swlib/ \
+   --ora-swlib-path <location-to-stage-installer-files> \
    --ora-swlib-type gcs \
    --instance-ip-addr ${INSTANCE_IP_ADDR}
    ```
@@ -123,7 +123,7 @@ Initial steps similar to those of the Single Instance installation.
    ./install-oracle.sh \
    --ora-swlib-bucket gs://[cloud-storage-bucket-name] \
    --backup-dest "+RECO" \
-   --ora-swlib-path /u02/swlib/ \
+   --ora-swlib-path <location-to-stage-installer-files> \
    --ora-swlib-type gcs \
    --cluster-type RAC \
    --cluster-config cluster_config.json
@@ -145,7 +145,7 @@ To create a standby database, add the following options to the command options t
    ./install-oracle.sh \
    --ora-swlib-bucket gs://[cloud-storage-bucket-name] \
    --instance-ip-addr ${INSTANCE_IP_ADDR} \
-   --ora-swlib-path /u02/swlib/ \
+   --ora-swlib-path <location-to-stage-installer-files> \
    --backup-dest "+RECO" \
    --ora-swlib-type gcs \
    --primary-ip-addr ${PRIMARY_IP_ADDR} \
@@ -299,7 +299,7 @@ Cloud](https://edelivery.oracle.com/) site (also known as Oracle "eDelivery"),
 and **patches** that you download from Oracle's [My Oracle
 Support](https://support.oracle.com/) (MOS) site.
 
-You can also download base software from 
+You can also download the base software from
 [Oracle Technology Network][https://www.oracle.com/database/technologies/oracle-database-software-downloads.html#db_ee).
 In this case, please rename the downloaded files to the
 [software delivery cloud equivalent](#required-oracle-software---download-summary)
@@ -931,8 +931,11 @@ for the data mount devices and the ASM disk group.
 
 In the data mount configuration file, you specify disk device attributes for:
 
-- Oracle software installation, which is usually mounted at /u01
-- Oracle diagnostic destination, which is usually mounted at /u02
+- Oracle software installation, which is usually mounted at `/u01`
+
+Optionally, you can specify a secondary disk device used for:
+
+- Oracle diagnostic destination, which is usually mounted at `/u0n`, where `n` represents any single digit [2-9] such as `/u02`.
 
 In the configuration file, specify the block devices (actual devices, not
 partitions), the mount point names, the file system types, and the mount options
@@ -945,6 +948,21 @@ fully qualified. The file name defaults to `data_mounts_config.json`.
 
 The following example shows a properly formatted JSON data mount configuration
 file:
+
+```json
+[
+    {
+        "purpose": "software",
+        "blk_device": "/dev/mapper/3600a098038314352502b4f782f446138",
+        "name": "u01",
+        "fstype":"xfs",
+        "mount_point":"/u01",
+        "mount_opts":"nofail"
+    }
+]
+```
+
+If desired, a secondary disk device (often desirable for the diag dest) can also be specified:
 
 ```json
 [
@@ -1051,14 +1069,14 @@ letter "u".
 Following this convention, the toolkit creates the following default file system
 mounts:
 
-- **/u01** - For Oracle software. For example, /u01/app/oracle/product.
+- **/u01** - For Oracle software. For example, `/u01/app/oracle/product`.
 
-- **/u02** - For other Oracle files, including software staging and, optionally, the
-  Oracle Automatic Diagnostic Repository (ADR).
+- **/u0n** - For other Oracle files, including software staging and, optionally, the
+  Oracle Automatic Diagnostic Repository (ADR). Where **_n_** is any number between 2-9, for example `/u02`.
 
 You don't have to use a separate file system, physical device, or logical volume
 for the software staging and other purposes. You can use the single file system,
-/u01, or whatever you choose to call it, if you want to.
+`/u01`, if you prefer.
 
 ### Database backup configuration
 
@@ -1588,15 +1606,23 @@ Specifies a file containing properly formed JSON text.</td>
 <table>
 <thead>
 <tr>
-<th>RMAN backup destination</th>
-<th><p><pre>
+<th>Attribute</th>
+<th>Parameters</th>
+<th>Parameter Values</th>
+<th>Notes</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>RMAN backup destination</td>
+<td><p><pre>
 BACKUP_DEST
 --backup-dest
-</pre></p></th>
-<th>user defined - no default<br>
-Example: +RECO</th>
-<th>Disk group name or NFS file share location. Can include formatting options,
-such as "/u02/db_backups/ORCL_%I_%T_%s_%p.bak", for example.<br>
+</pre></p></td>
+<td>user defined - no default<br>
+Example: +RECO</td>
+<td>Disk group name or NFS file share location. Can include formatting options,
+such as "/u0n/db_backups/ORCL_%I_%T_%s_%p.bak" (where <b>n</b> is any single digit number).<br>
 <br>
 When writing to a non-ASM disk group location, include a valid RMAN format
 specification to ensure file name uniqueness, such as the example string
@@ -1604,10 +1630,9 @@ shown above.<br>
 <br>
 If you are writing to a local file system, the
 directory does not have to exist, but initial backups will fail if the
-destination is not available or writeable.</th>
+destination is not available or writeable.</td>
 </tr>
-</thead>
-<tbody>
+</tr>
 <tr>
 <td>RMAN full DB backup redundancy</td>
 <td><p><pre>
@@ -2405,8 +2430,8 @@ $ ./cleanup-oracle.sh --ora-version 19 \
 --inventory-file ./inventory_files/inventory_oracledb1_ORCL \
 --yes-i-am-sure \
 --ora-disk-mgmt udev \
---ora-swlib-path /u02/oracle_install \
---ora-staging /u02/oracle_install \
+--ora-swlib-path /u0n/oracle_install \
+--ora-staging /u0n/oracle_install \
 --ora-asm-disks asm_disk_config.json \
 --ora-data-mounts data_mounts_config.json
 

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -25,7 +25,6 @@ swlib_path_default: "{{ oracle_user_data_mounts|selectattr('purpose', 'match', '
 # Installation related variables from dbasm
 oracle_user_data_mounts_default:
   - { purpose: software, blk_device: /dev/BOGUS, fstype: xfs, mount_point: /u01, mount_opts: "nofail" }
-  - { purpose: diag, blk_device: /dev/BOGUS, fstype: xfs, mount_point: /u02, mount_opts: "nofail" }
 data_mounts_definition_file: "{{ lookup('env','ORA_DATA_MOUNTS')|default('data_mounts_config.json',true) }}"
 data_mounts_input: "{{ lookup('file',data_mounts_definition_file,errors='ignore') }}"
 oracle_user_data_mounts: "{{ data_mounts_input | default(oracle_user_data_mounts_default,true) }}"

--- a/manage_devices_on_vm.sh
+++ b/manage_devices_on_vm.sh
@@ -28,7 +28,7 @@ PROJECT=$(gcloud config get-value project)   # (-p)       Project name
 #
 # The devices names and sizes we want to create or delete
 #
-declare -A disks=( [u01]=32GB [u02]=32GB [data]=10GB [reco]=12GB [demo]=10GB [swap]=32GB )
+declare -A disks=( [u01]=32GB [data]=10GB [reco]=12GB [demo]=10GB [swap]=32GB )
 #
 # Usage function
 #

--- a/roles/host-storage/defaults/main.yml
+++ b/roles/host-storage/defaults/main.yml
@@ -15,4 +15,3 @@
 ---
 oracle_user_data_mounts:
   - { purpose: software, blk_device: /dev/sdb, fstype: xfs, mount_point: /u01, mount_opts: nofail }
-  - { purpose: other, blk_device: /dev/sdc, fstype: xfs, mount_point: /u02 , mount_opts: nofail }


### PR DESCRIPTION
### Problem Description:
Remove /u02 mount point from default configuration. Currently the user has to define mandatory two mount points /u01 and /u02 otherwise the installation fails. The mount point /u02 should be optional. Client can have /u02 if he or she wants to store swlib and the diag_dest to /u02.

### Solution Overview:
Remove settings for /u02 from all of the json configuration files as well as the Ansible files. Update document and remove /u02.

### Test Commands:
**Test case 1: Without /u02 mount point**

1. Create VM without /u02 mount point.

1. Install Oracle with command below to exclude /u02 at all.

> time ./install-oracle.sh \ 
> --ora-version 19.3.0.0.0 \
> --ora-edition EE \ 
> --ora-swlib-bucket <GS Bucket where Oracle database software and Patches resides> \
> --backup-dest "+RECO" \ 
> --ora-swlib-type gcs \ 
> --instance-ip-addr <IP ADDRESS OF VM> \
> --instance-hostname <NAME OF VM INSTANCE> \
> --allow-install-on-vm

3. Install Oracle with command below to include /u02.

> time ./install-oracle.sh \
> --ora-version 19.3.0.0.0 \ 
> --ora-edition EE \ 
> --ora-swlib-bucket <GS Bucket where Oracle database software and Patches resides> \
> --backup-dest "+RECO" \
> --ora-swlib-path /u02/swlib/ \
> --ora-swlib-type gcs \
> --instance-ip-addr <IP ADDRESS OF VM> \ 
> --instance-hostname <NAME OF VM INSTANCE> \
> --allow-install-on-vm

**Test case 2: With /u02 mount point**

1. Create VM with /u02 mount point.

1. Add /u02 mount point in json file data_mounts_config.json as in the example below. Check block device names and modify them if required.

> [
>     {
>         "purpose": "software",
> 	"blk_device": "/dev/sdb",
> 	"name": "u01",
> 	"fstype":"xfs",
> 	"mount_point":"/u01",
> 	"mount_opts":"nofail"
>     },
>     {
>         "purpose": "diag_dest",
> 	"blk_device": "/dev/sdc",
> 	"name": "u02",
> 	"fstype":"xfs",
> 	"mount_point":"/u02",
> 	"mount_opts":"nofail"
>     }
> ]

1. Install Oracle with command below.

> time ./install-oracle.sh \
> --ora-version 19.3.0.0.0 \
> --ora-edition EE \
> --ora-swlib-bucket <GS Bucket where Oracle database software and Patches resides> \
> --backup-dest "+RECO" \
> --ora-swlib-path /u02/swlib/ \
> --ora-swlib-type gcs \
> --instance-ip-addr <IP ADDRESS OF VM> \
> --instance-hostname <NAME OF VM INSTANCE> \
> --allow-install-on-vm

### Expected Result:

1. All above install-oracle.sh should be completed without error.
2. First install-oracle.sh command should not create a directory /u02 and /u02 should not exist at all.
3. Second install-oracle.sh command must create a directory /u02 and store swlib as child directory to /u02.
4. Third install-oracle.sh command must create /u02 mount point as separate drive and use it to store swlib.


