### PR TITLE
Enable serial port output logging for the control node

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -194,6 +194,7 @@ resource "google_compute_instance" "control_node" {
 
   metadata = {
     enable-oslogin = "TRUE"
+    serial-port-logging-enable = true
   }
 
   depends_on = [module.compute_instance]


### PR DESCRIPTION
# The problem

The transient control node does most of its work from the startup script, which is logged via the serial port.  But after the VM is deleted, the serial port output is no longer available.

# The solution

Send the output to Cloud Logging, where it persists.
https://cloud.google.com/compute/docs/troubleshooting/viewing-serial-port-output#enable-stackdriver

# Sample output

Sample Terraform output:
https://gist.github.com/mfielding/28be7a0c31b8fc676c00b0f331faf7dc

Validation of the VM config:

```
$ gcloud compute instances describe https://www.googleapis.com/compute/v1/projects/project/zones/us-central1-b/instances/control-node-b4bfad46 --flatten="metadata{]" --format='default(items[1])'
---
items:
- null
- key: serial-port-logging-enable
  value: 'true'
$ gcloud compute instances get-serial-port-output --zone=us-central1-b control-node-b4bfad46 | head
CSM BBS Table full.
BdsDxe: loading Boot0001 "UEFI Google PersistentDisk " from PciRoot(0x0)/Pci(0x3,0x0)/Scsi(0x1,0x0)
BdsDxe: starting Boot0001 "UEFI Google PersistentDisk " from PciRoot(0x0)/Pci(0x3,0x0)/Scsi(0x1,0x0)

UEFI: Attempting to start image.
Description: UEFI Google PersistentDisk
FilePath: PciRoot(0x0)/Pci(0x3,0x0)/Scsi(0x1,0x0)
OptionNumber: 1.

Welcome to GRUB!
```