### PR TITLE
Revert "Enable serial port output logging for the control node"

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -198,7 +198,6 @@ resource "google_compute_instance" "control_node" {
 
   metadata = {
     enable-oslogin = "TRUE"
-    serial-port-logging-enable = true
   }
 
   depends_on = [module.compute_instance]


### PR DESCRIPTION
More testing with this feature enabled shows that startup-script output is now double-logged:  once from the serial-port output, but also from the startup-script wrapper itself.  Given that log storage costs money, it's probably better to rely on the startup-script logging alone.

Sample (now non-duplicated) output:  https://gist.github.com/mfielding/33256b84a5f223e7acf90931d39a8503

Reverts google/oracle-toolkit#269