### PR TITLE
Change to `shell` module and the `unzip` command for improved decompression performance

### DIFF
--- a/roles/gi-setup/tasks/gi-install.yml
+++ b/roles/gi-setup/tasks/gi-install.yml
@@ -37,13 +37,12 @@
   tags: gi-setup
 
 - name: gi-install | Unzip GI patch
-  unarchive:
-    src: "{{ swlib_path }}/{{ item.patchfile }}"
-    dest: "{{ swlib_unzip_path }}"
-    remote_src: true
+  # Using the "shell" module instead of "unarchive" for unzip performance
+  shell: |
+    unzip -o -q "{{ swlib_path }}/{{ item.patchfile }}" -d "{{ swlib_unzip_path }}"
+    chown -R {{ grid_user }}:{{ oracle_group }} "{{ swlib_unzip_path }}"
+  args:
     creates: .gi_patch_{{ oracle_rel }}
-    owner: "{{ grid_user }}"
-    group: "{{ oracle_group }}"
   with_items:
     - "{{ gi_patches }}"
   when: item.release == oracle_rel and item.category == 'RU' and item.category != "HAS_interim_patch"
@@ -61,10 +60,8 @@
 - name: gi-install | Unzipping GI software
   become: true
   become_user: "{{ grid_user }}"
-  unarchive:
-    src: "{{ swlib_path }}/{{ item.name }}"
-    dest: "{{ install_unzip_path }}"
-    remote_src: true
+  # Using the "shell" module instead of "unarchive" for unzip performance
+  shell: unzip -o -q "{{ swlib_path }}/{{ item.name }}" -d "{{ install_unzip_path }}"
   with_items:
     - "{{ osw.files }}"
   tags: gi-setup,sw-unzip
@@ -224,10 +221,8 @@
 - name: gi-install | Unzip other pre-HAS critical interim patches
   become: true
   become_user: "{{ grid_user }}"
-  unarchive:
-    src: "{{ swlib_path }}/{{ item.files.0.name }}"
-    dest: "{{ swlib_unzip_path }}/{{ item.files.0.name | replace('.zip','') }}"
-    remote_src: true
+  # Using the "shell" module instead of "unarchive" for unzip performance
+  shell: unzip -o -q "{{ swlib_path }}/{{ item.files.0.name }}" -d "{{ swlib_unzip_path }}/{{ item.files.0.name | replace('.zip','') }}"
   with_items:
     - "{{ gi_interim_patches }}"
   when: item.version == osw.version and item.category == "HAS_interim_patch"

--- a/roles/patch/tasks/main.yml
+++ b/roles/patch/tasks/main.yml
@@ -45,7 +45,7 @@
       file:
         path: "{{ grid_home }}/OPatch"
         state: absent
-    
+
     - name: (GI) Create empty OPatch directory
       file:
         path: "{{ grid_home }}/OPatch"
@@ -86,10 +86,8 @@
   tags: update-opatch-db
 
 - name: (GI) Unzip patch
-  unarchive:
-    src: "{{ swlib_path }}/{{ item.patchfile }}"
-    dest: "{{ swlib_unzip_path }}"
-    remote_src: true
+  # Using the "shell" module instead of "unarchive" for unzip performance
+  shell: unzip -o -q "{{ swlib_path }}/{{ item.patchfile }}" -d "{{ swlib_unzip_path }}"
   with_items:
     - "{{ gi_patches }}"
   when: item.release == oracle_rel and item.category != "HAS_interim_patch"
@@ -144,10 +142,8 @@
   tags: patch-grid,sw-remove
 
 - name: (RDBMS) Unzip patch
-  unarchive:
-    src: "{{ swlib_path }}/{{ item.patchfile }}"
-    dest: "{{ swlib_unzip_path }}"
-    remote_src: true
+  # Using the "shell" module instead of "unarchive" for unzip performance
+  shell: unzip -o -q "{{ swlib_path }}/{{ item.patchfile }}" -d "{{ swlib_unzip_path }}"
   with_items:
     - "{{ rdbms_patches }}"
   when: item.release == oracle_rel

--- a/roles/patch/tasks/rac-opatch.yml
+++ b/roles/patch/tasks/rac-opatch.yml
@@ -14,12 +14,10 @@
 
 ---
 - name: rac-opatch | Unzip GI patch
-  unarchive:
-    src: "{{ swlib_path }}/{{ item.patchfile }}"
-    dest: "{{ swlib_unzip_path }}"
-    remote_src: true
-    owner: "{{ grid_user }}"
-    group: "{{ oracle_group }}"
+  # Using the "shell" module instead of "unarchive" for unzip performance
+  shell: |
+    unzip -o -q "{{ swlib_path }}/{{ item.patchfile }}" -d "{{ swlib_unzip_path }}"
+    chown -R {{ grid_user }}:{{ oracle_group }} "{{ swlib_unzip_path }}"
   with_items:
     - "{{ gi_patches }}"
   when: item.release == oracle_rel and item.category != "HAS_interim_patch"
@@ -192,12 +190,10 @@
   tags: rac-opatch
 
 - name: rac-opatch | Unzip RDBMS patch
-  unarchive:
-    src: "{{ swlib_path }}/{{ item.patchfile }}"
-    dest: "{{ swlib_unzip_path }}"
-    remote_src: true
-    owner: "{{ oracle_user }}"
-    group: "{{ oracle_group }}"
+  # Using the "shell" module instead of "unarchive" for unzip performance
+  shell: |
+    unzip -o -q "{{ swlib_path }}/{{ item.patchfile }}" -d "{{ swlib_unzip_path }}"
+    chown -R {{ oracle_user }}:{{ oracle_group }} "{{ swlib_unzip_path }}"
   with_items:
     - "{{ rdbms_patches }}"
   when: item.release == oracle_rel

--- a/roles/rac-db-setup/tasks/rac-db-install-11.2-12.1.yml
+++ b/roles/rac-db-setup/tasks/rac-db-install-11.2-12.1.yml
@@ -57,12 +57,10 @@
   tags: rac-db,db-dirs
 
 - name: rac-db-install | Unzip OneOff patch
-  unarchive:
-    src: "{{ swlib_path }}/{{ item.patchfile }}"
-    dest: "{{ swlib_unzip_path }}"
-    remote_src: true
-    owner: "{{ oracle_user }}"
-    group: "{{ oracle_group }}"
+  # Using the "shell" module instead of "unarchive" for unzip performance
+  shell: |
+    unzip -o -q "{{ swlib_path }}/{{ item.patchfile }}" -d "{{ swlib_unzip_path }}"
+    chown -R {{ oracle_user }}:{{ oracle_group }} "{{ swlib_unzip_path }}"
   with_items:
     - "{{ rdbms_patches }}"
   when: item.release == oracle_rel
@@ -72,10 +70,8 @@
 - name: rac-db-install | Unzipping software
   become: true
   become_user: "{{ oracle_user }}"
-  unarchive:
-    src: "{{ swlib_path }}/{{ item }}"
-    dest: "{{ install_unzip_path }}"
-    remote_src: true
+  # Using the "shell" module instead of "unarchive" for unzip performance
+  shell: unzip -o -q "{{ swlib_path }}/{{ item }}" -d "{{ install_unzip_path }}"
   with_items:
     - "{{ osw_files }}"
   tags: rac-db,sw-unzip

--- a/roles/rac-db-setup/tasks/rac-db-install.yml
+++ b/roles/rac-db-setup/tasks/rac-db-install.yml
@@ -65,12 +65,10 @@
   tags: rac-db,db-dirs
 
 - name: rac-db-install | Unzip OneOff patch
-  unarchive:
-    src: "{{ swlib_path }}/{{ item.patchfile }}"
-    dest: "{{ swlib_unzip_path }}"
-    remote_src: true
-    owner: "{{ oracle_user }}"
-    group: "{{ oracle_group }}"
+  # Using the "shell" module instead of "unarchive" for unzip performance
+  shell: |
+    unzip -o -q "{{ swlib_path }}/{{ item.patchfile }}" -d "{{ swlib_unzip_path }}"
+    chown -R {{ oracle_user }}:{{ oracle_group }} "{{ swlib_unzip_path }}"
   with_items:
     - "{{ rdbms_patches }}"
   when: item.release == oracle_rel
@@ -80,10 +78,8 @@
 - name: rac-db-install | Unzipping software
   become: true
   become_user: "{{ oracle_user }}"
-  unarchive:
-    src: "{{ swlib_path }}/{{ item }}"
-    dest: "{{ install_unzip_path }}"
-    remote_src: true
+  # Using the "shell" module instead of "unarchive" for unzip performance
+  shell: unzip -o -q "{{ swlib_path }}/{{ item }}" -d "{{ install_unzip_path }}"
   with_items:
     - "{{ osw_files }}"
   tags: rac-db,sw_unzip

--- a/roles/rac-gi-setup/tasks/rac-gi-install.yml
+++ b/roles/rac-gi-setup/tasks/rac-gi-install.yml
@@ -28,13 +28,12 @@
   tags: rac-gi
 
 - name: rac-gi-install | Unzip GI patch
-  unarchive:
-    src: "{{ swlib_path }}/{{ item.patchfile }}"
-    dest: "{{ swlib_unzip_path }}"
-    remote_src: true
+  # Using the "shell" module instead of "unarchive" for unzip performance
+  shell: |
+    unzip -o -q "{{ swlib_path }}/{{ item.patchfile }}" -d "{{ swlib_unzip_path }}"
+    chown -R {{ grid_user }}:{{ oracle_group }} "{{ swlib_unzip_path }}"
+  args:
     creates: .gi_patch_{{ oracle_rel }}
-    owner: "{{ grid_user }}"
-    group: "{{ oracle_group }}"
   with_items:
     - "{{ gi_patches }}"
   when: item.release == oracle_rel and item.category == 'RU' and item.category != "HAS_interim_patch"
@@ -65,10 +64,9 @@
 - name: rac-gi-install | Unzip HA interim patches
   become: true
   become_user: "{{ grid_user }}"
-  unarchive:
-    src: "{{ swlib_path }}/{{ item | json_query('.files[*].name') | join() }}"
-    dest: "{{ swlib_unzip_path }}"
-    remote_src: true
+  # Using the "shell" module instead of "unarchive" for unzip performance
+  shell: unzip -o -q "{{ swlib_path }}/{{ item | json_query('.files[*].name') | join() }}" -d "{{ swlib_unzip_path }}"
+  args:
     creates: .ha_patch_{{ oracle_ver }}
   with_items:
     - "{{ gi_interim_patches }}"
@@ -86,10 +84,8 @@
 - name: rac-gi-install | Unzip software
   become: true
   become_user: "{{ grid_user }}"
-  unarchive:
-    src: "{{ swlib_path }}/{{ item }}"
-    dest: "{{ install_unzip_path }}"
-    remote_src: true
+  # Using the "shell" module instead of "unarchive" for unzip performance
+  shell: unzip -o -q "{{ swlib_path }}/{{ item }}" -d "{{ install_unzip_path }}"
   with_items:
     - "{{ osw_files }}"
   tags: rac-gi,sw-unzip

--- a/roles/rdbms-setup/tasks/rdbms-install.yml
+++ b/roles/rdbms-setup/tasks/rdbms-install.yml
@@ -39,12 +39,10 @@
   tags: rdbms-setup,rel-patch
 
 - name: rdbms-install | Unzip OneOff patch
-  unarchive:
-    src: "{{ swlib_path }}/{{ item.patchfile }}"
-    dest: "{{ swlib_unzip_path }}"
-    remote_src: true
-    owner: "{{ oracle_user }}"
-    group: "{{ oracle_group }}"
+  # Using the "shell" module instead of "unarchive" for unzip performance
+  shell: |
+    unzip -o -q "{{ swlib_path }}/{{ item.patchfile }}" -d "{{ swlib_unzip_path }}"
+    chown -R {{ oracle_user }}:{{ oracle_group }} "{{ swlib_unzip_path }}"
   with_items:
     - "{{ rdbms_patches }}"
   when: item.release == oracle_rel
@@ -54,10 +52,8 @@
 - name: rdbms-install | Unzipping software
   become: true
   become_user: "{{ oracle_user }}"
-  unarchive:
-    src: "{{ swlib_path }}/{{ item.name }}"
-    dest: "{{ install_unzip_path }}"
-    remote_src: true
+  # Using the "shell" module instead of "unarchive" for unzip performance
+  shell: unzip -o -q "{{ swlib_path }}/{{ item.name }}" -d "{{ install_unzip_path }}"
   with_items:
     - "{{ osw.files }}"
   tags: rdbms-setup,sw-unzip


### PR DESCRIPTION
## Change Description:

Change the file unzip approach for large files to use `unzip` on the Managed Host through the `shell` module instead of the existing Ansible `unarchive` module.

## Solution Overview:

The Ansible `unarchive` module may have more overhead and consequently be less performant than using the `shell` module to run the `unzip` command directly on the Managed Host.

Therefore, changed task steps that unzip large, or potentially large, software zip files to use the `shell` module and the `unzip` command for reduced task duration.

Since the OPatch zip files are consistently comparatively small, unzipping of OPatch was not changed.

## Test Results:

Ran full 19c EE installation, configuration, and patching playbooks with and without this change to compare the results. Timing instrumentation provided from the `callbacks_enabled = ansible.posix.profile_tasks` option added to the `ansible.cfg` file.

Results of just the relevant tasks from the existing toolkit without this change:

```plaintext
rdbms-setup : rdbms-install | Unzipping software ----------------------- 67.16s
gi-setup : gi-install | Unzipping GI software -------------------------- 55.85s
gi-setup : gi-install | Unzip GI patch ---------------------------------- 4.31s
rdbms-setup : rdbms-install | Unzip OneOff patch ------------------------ 2.52s
patch : (RDBMS) Unzip patch -------------------------------------------- 64.55s
patch : (GI) Unzip patch ----------------------------------------------- 64.24s
```

Results with this change:

```plaintext
rdbms-setup : rdbms-install | Unzipping software ----------------------- 50.92s
gi-setup : gi-install | Unzipping GI software -------------------------- 43.74s
gi-setup : gi-install | Unzip GI patch ---------------------------------- 4.47s
rdbms-setup : rdbms-install | Unzip OneOff patch ------------------------ 2.68s
patch : (RDBMS) Unzip patch -------------------------------------------- 53.19s
patch : (GI) Unzip patch ----------------------------------------------- 52.42s
```

For this particular test case, the improvement in these steps was ~**20%**.

> **NOTE:** While some steps such as "Unzip GI patch" and "Unzip OneOff patch" showed no improvement, and actually regressed by a few tenths of a second, these files are currently small and the change minimal. However, future patch files processed by these steps could potentially be large and therefore leaving them with the new approach is probably advisable.

Also tested various other Oracle and OS combinations:

- Oracle 11g (`--no-patch`) install on RHEL7
- Oracle 12cR2 (`--no-patch`) install on OL7
- Oracle 18c (`--no-patch`) install on RHEL8
- Oracle 21c install on OL8

> **IMPORTANT:** RAC tasks were changed but have not been verified via test toolkit execution.
