### PR TITLE
Require upper/lowercase and digits in generated passwords

### DIFF
--- a/roles/pwgen/files/pwgen.sh
+++ b/roles/pwgen/files/pwgen.sh
@@ -32,8 +32,8 @@ DCHAR="$(cat /dev/urandom | tr -dc [:digit:] | head -c1)"
 # have a symbol
 SCHAR="$(cat /dev/urandom | tr -dc ${PWSYM} | head -c1)"
 # upper, lower, digit, some symbols
-RCHAR="$(cat /dev/urandom | tr -dc [:alnum:]${PWSYM} | head -c$((PWLEN - 5)))"
+RCHAR="$(cat /dev/urandom | tr -dc [:alnum:]${PWSYM} | head -c$((PWLEN - 6)))"
 # wrap the symbol into the password
-RPASS="$(echo "${UCHAR}${LCHAR}${SCHAR}${RCHAR}" | fold -c -w1 | shuf | tr -d '\n')"
+RPASS="$(echo "${UCHAR}${LCHAR}${DCHAR}${SCHAR}${RCHAR}" | fold -c -w1 | shuf | tr -d '\n')"
 
 echo "${FCHAR}${RPASS}${FCHAR}"


### PR DESCRIPTION
Occasionally, we see dbca warnings in the logs:

> Oracle recommends that the password entered should be at least 8 characters in length, contain at least 1 uppercase character, 1 lower case character and 1 digit [0-9]

These happen because the password may not have actually contained a digit, or both upper- and lower-case characters.

This change attempts to maintain the existing semantics of pwgen.sh, but to ensure the password includes uppercase, lowercase, a digit, and a symbol.

This change necessarily reduces the number of possible passwords, but should not be material for the 16-character passwords we generate.

Some sample passwords:

```
$ for i in $(seq 1 10); do bash pwgen.sh; done
T8JukIEGdowp*1T
bUViCqGwX3n~~bb
Lctl8@SYhLkUgNL
oIVVN@*jnOcjfeo
pc3nXFN8+9GTbzp
pkmm@o0mjmshhWp
FbR*@n1uABkOOKF
FHN*@h2VhuQ9mLF
IEaI8E+4~IquuxI
WU4YNuMkw2g@s9W
```