### PR TITLE
DBID Logger enhanced to handle extra spaces in the DBID output

### DIFF
--- a/roles/dbid-logger/tasks/main.yml
+++ b/roles/dbid-logger/tasks/main.yml
@@ -35,7 +35,7 @@
 
 - name: Extract DBID from query result
   ansible.builtin.set_fact:
-    oracle_dbid: "{{ dbid_query_result.stdout | trim if not dbid_query_result.failed else '' }}"
+    oracle_dbid: "{{ dbid_query_result.stdout | trim }}"
 
 - name: Output DBID
   ansible.builtin.debug:


### PR DESCRIPTION
The updated playbook Sets Heading off and sql-trims the DBID. This new step effectively removes all leading and trailing whitespace from each line of the SQL query result before the DBID is extracted, preventing failures caused by inconsistent formatting.