### PR TITLE
Only log DBID on the first RAC node

### DIFF
--- a/config-rac-db.yml
+++ b/config-rac-db.yml
@@ -45,7 +45,7 @@
   tags: rac-db-adjustments,rac-db-backups,rac-validation-scripts
   
 - name: Get and Log Oracle DBID
-  hosts: dbasm
+  hosts: dbasm[0]
   remote_user: "{{ oracle_user }}"
   become: true
   become_user: oracle


### PR DESCRIPTION
In a RAC database, both nodes have the same DBID. And as we set {{ oracle_sid }} to the first node's side, the same command won't work on the second.

For example, from https://oss.gprow.dev/view/gs/gcp-oracle-prow-bucket/pr-logs/pull/google_oracle-toolkit/316/oracle-toolkit-install-rac-on-bms/1957827226229542912:

```
TASK [dbid-logger : Execute SQL query to get DBID] *****************************
changed: [g370069685-s001]
fatal: [g321263485-s001]: FAILED! => {"changed": true, "cmd": "set -o pipefail\nsqlplus -s / as sysdba <<EOF\nWHENEVER SQLERROR EXIT SQL.SQLCODE\nSET HEADING OFF\nSET FEEDBACK OFF\nSET LINESIZE 999\nSET PAGESIZE 0\nSET TRIMSPOOL ON\nSELECT dbid FROM v\\$database;\nEXIT;\nEOF\n", "delta": "0:00:01.024942", "end": "2025-08-19 16:56:15.913293", "msg": "non-zero return code", "rc": 10, "start": "2025-08-19 16:56:14.888351", "stderr": "", "stderr_lines": [], "stdout": "SELECT dbid FROM v$database\n*\nERROR at line 1:\nORA-01034: ORACLE not available\nProcess ID: 0\nSession ID: 0 Serial number: 0", "stdout_lines": ["SELECT dbid FROM v$database", "*", "ERROR at line 1:", "ORA-01034: ORACLE not available", "Process ID: 0", "Session ID: 0 Serial number: 0"]}
...ignoring
```

After this CL, the RAC test no longer reports errors:

```
TASK [dbid-logger : Execute SQL query to get DBID] *****************************
changed: [g370069685-s001]
TASK [dbid-logger : Extract DBID from query result] ****************************
ok: [g370069685-s001]
TASK [dbid-logger : Output DBID] ***********************************************
ok: [g370069685-s001] => {
    "msg": "1737370523"
}
```