### PR TITLE
Rename Ansible variable `asm_disk_management` to `ora_disk_management`

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -15,7 +15,7 @@
 ---
 # Defined boolean if installing Free Edition
 free_edition: "{{ oracle_edition == 'FREE' }}"
-gi_install: "{{ not free_edition and not asm_disk_management == 'fs' }}"
+gi_install: "{{ not free_edition and not ora_disk_management == 'fs' }}"
 
 # Installation related variables:
 swlib_path: "{{ lookup('env','ORA_SWLIB_PATH') | lower | default(swlib_path_default,true) }}"
@@ -81,7 +81,7 @@ charset: "{{ lookup('env','ORA_DB_CHARSET') | default('AL32UTF8',true) }}"
 ncharset: "{{ lookup('env','ORA_DB_NCHARSET') | default('AL16UTF16',true) }}"
 
 # ASM and storage related variables:
-asm_disk_management: "{{ lookup('env','ORA_DISK_MGMT') | lower | default('udev',true) }}"
+ora_disk_management: "{{ lookup('env','ORA_DISK_MGMT') | lower | default('udev',true) }}"
 role_separation: "{{ lookup('env','ORA_ROLE_SEPARATION') | default('true', true) | lower | bool }}"
 data_destination: "{{ lookup('env','ORA_DATA_DESTINATION') | default('DATA',true) }}"
 reco_destination: "{{ lookup('env','ORA_RECO_DESTINATION') | default('RECO',true) }}"

--- a/roles/brute-ora-cleanup/tasks/main.yml
+++ b/roles/brute-ora-cleanup/tasks/main.yml
@@ -320,7 +320,7 @@
   with_subelements:
     - "{{ asm_disks }}"
     - disks
-  when: asm_disk_management == "asmlib"
+  when: ora_disk_management == "asmlib"
   register: delete_asm_disks
   ignore_errors: true
 
@@ -331,7 +331,7 @@
     name: "*oracleasm*"
     state: absent
     lock_timeout: "{{ pkg_mgr_lock_timeout }}"
-  when: asm_disk_management == "asmlib"
+  when: ora_disk_management == "asmlib"
   register: remove_oracleasm
 
 - include_role:
@@ -469,13 +469,13 @@
   file:
     path: /etc/udev/rules.d/99-oracle-asmdevices.rules
     state: absent
-  when: asm_disk_management in ["udev", "asmudev"]
+  when: ora_disk_management in ["udev", "asmudev"]
 
 - name: (udev) Reload rules
   become: true
   become_user: root
   shell: ( /sbin/udevadm control --reload-rules && /sbin/udevadm trigger )
-  when: asm_disk_management in ["udev", "asmudev"]
+  when: ora_disk_management in ["udev", "asmudev"]
 
 - name: Remove oracle kernel modules
   become: true

--- a/roles/check-swlib/tasks/main.yml
+++ b/roles/check-swlib/tasks/main.yml
@@ -36,7 +36,7 @@
   failed_when: "'ERROR' in base_repo_files.stdout"
   changed_when: false
   ignore_errors: true
-  loop: "{{ (((gi_software + gi_interim_patches) if asm_disk_management != 'fs' else []) + rdbms_software) | subelements('files') }}"
+  loop: "{{ (((gi_software + gi_interim_patches) if ora_disk_management != 'fs' else []) + rdbms_software) | subelements('files') }}"
   when: item.0.version == oracle_ver
   register: base_repo_files
 
@@ -77,7 +77,7 @@
   ignore_errors: true
   with_items: >-
     {{ rdbms_patch_files | default([]) +
-       gi_patches | default([]) if asm_disk_management != 'fs' else
+       gi_patches | default([]) if ora_disk_management != 'fs' else
        rdbms_patch_files | default([]) }}
   when:
     - item.base == oracle_ver

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -64,7 +64,7 @@ asm_groups:
 extra_asm_groups:
   - { group: dba      ,       gid: 54322 }
 
-asm_diskstring: "{% if asm_disk_management == 'asmlib' %}ORCL:*{% else %}/dev/{{ path_udev }}/*{% endif %}"
+asm_diskstring: "{% if ora_disk_management == 'asmlib' %}ORCL:*{% else %}/dev/{{ path_udev }}/*{% endif %}"
 
 oracle_dirs:
   - { name: "{{ swlib_unzip_path }}", owner: "{{ oracle_user }}", group: "{{ oracle_group }}", mode: "ug=rwx,o=rx" }

--- a/roles/gi-setup/tasks/asm-create.yml
+++ b/roles/gi-setup/tasks/asm-create.yml
@@ -74,7 +74,7 @@
     ORACLE_VERSION: "{{ oracle_ver }}"
     ORACLE_SID: "{{ asm_sid }}"
     LD_LIBRARY_PATH: "{{ grid_home }}/lib:${LD_LIBRARY_PATH}"
-  when: asm_disk_management == "asmlib"
+  when: ora_disk_management == "asmlib"
   with_items: "{{ asm_disks }}"
   register: create_dg
   failed_when: "'ERROR' in create_dg.stdout"
@@ -99,7 +99,7 @@
     ORACLE_VERSION: "{{ oracle_ver }}"
     ORACLE_SID: "{{ asm_sid }}"
     LD_LIBRARY_PATH: "{{ grid_home }}/lib:${LD_LIBRARY_PATH}"
-  when: asm_disk_management in ["udev", "asmudev"]
+  when: ora_disk_management in ["udev", "asmudev"]
   with_items: "{{ asm_disks }}"
   register: create_dg
   failed_when: "'ERROR' in create_dg.stdout"

--- a/roles/ora-host/tasks/main.yml
+++ b/roles/ora-host/tasks/main.yml
@@ -279,7 +279,7 @@
 
 - name: (asmlib) | ASM device management via asmlib or udev?
   debug:
-    msg: "asm_disk_management is set to {{ asm_disk_management }}"
+    msg: "ora_disk_management is set to {{ ora_disk_management }}"
     verbosity: 0
   tags: asm-disks
 
@@ -290,7 +290,7 @@
     state: present
     label: gpt
   when:
-    - asm_disk_management != "fs"
+    - ora_disk_management != "fs"
     - "'mapper' not in item.1.blk_device"
   run_once: true
   with_subelements:
@@ -301,7 +301,7 @@
 - include_role:
     name: common
     tasks_from: populate-asm-disks.yml
-  when: asm_disk_management != "fs"
+  when: ora_disk_management != "fs"
 
 - name: (debug) asm disk configuration
   debug:
@@ -310,7 +310,7 @@
       - asm_def_file {{ asm_definition_file }}
       - asm_disk_input {{ asm_disk_input }}
     verbosity: 0
-  when: asm_disk_management != "fs"
+  when: ora_disk_management != "fs"
   tags: asm-disks
 
 ######## Udev rules for non-multipath disks ########
@@ -321,7 +321,7 @@
   shell: udevadm info --query=all --name={{ item.1.blk_device }} | grep ID_SERIAL_SHORT | awk -F'=' '{print $2}'
   register: udevadm_result_nonmultipath
   when:
-    - asm_disk_management in ["udev", "asmudev"]
+    - ora_disk_management in ["udev", "asmudev"]
     - "'mapper' not in item.1.blk_device"
   with_subelements:
     - "{{ asm_disks }}"
@@ -399,7 +399,7 @@
   become: true
   become_user: root
   shell: ( /sbin/udevadm control --reload-rules && /sbin/udevadm trigger && /sbin/partprobe )
-  when: asm_disk_management in ["udev", "asmudev"]
+  when: ora_disk_management in ["udev", "asmudev"]
   tags: asm-disks
 
 - name: (asmlib) Install Oracle ASM libraries
@@ -407,7 +407,7 @@
     name: "{{ oracleasm_libs }}"
     state: present
     lock_timeout: "{{ pkg_mgr_lock_timeout }}"
-  when: asm_disk_management == "asmlib"
+  when: ora_disk_management == "asmlib"
   tags: oracleasmlib
 
 - name: (asmlib) Configure oracleasm
@@ -420,7 +420,7 @@
     /usr/sbin/oracleasm scandisks
     cat /etc/sysconfig/oracleasm
   register: asmconfig
-  when: asm_disk_management == "asmlib"
+  when: ora_disk_management == "asmlib"
   tags: asm-disks
 
 - name: (asmlib) Create Oracle ASM raw disks
@@ -430,7 +430,7 @@
   with_subelements:
     - "{{ asm_disks }}"
     - disks
-  when: asm_disk_management == "asmlib"
+  when: ora_disk_management == "asmlib"
   register: asmraw
   failed_when: "( ( asmraw.rc != 0 ) and ( 'ERROR' in asmraw.stdout ) ) or ( ( asmraw.rc != 0 ) and ( 'is already labeled for ASM disk' not in asmraw.stdout ) )"
   changed_when: "'Writing disk header: done' in asmraw.stdout"
@@ -443,7 +443,7 @@
   with_subelements:
     - "{{ asm_disks }}"
     - disks
-  when: asm_disk_management == "asmlib"
+  when: ora_disk_management == "asmlib"
   register: asmlv
   failed_when: "( ( asmlv.rc != 0 ) and ( 'ERROR' in asmlv.stdout ) ) or ( ( asmlv.rc != 0 ) and ( 'is already labeled for ASM disk' not in asmlv.stdout ) )"
   changed_when: "'Writing disk header: done' in asmlv.stdout"
@@ -457,7 +457,7 @@
     /usr/sbin/oracleasm listdisks
     ls -l /dev/oracleasm/disks
   register: listdisks
-  when: asm_disk_management == "asmlib"
+  when: ora_disk_management == "asmlib"
   tags: asm-disks
 
 - name: (asmlib) Restart oracleasm
@@ -465,7 +465,7 @@
     state: restarted
     name: oracleasm
     scope: system
-  when: asm_disk_management == "asmlib"
+  when: ora_disk_management == "asmlib"
   tags: asm-disks
 
 - name: (asmlib) ASM listing results
@@ -477,5 +477,5 @@
   with_items:
     - "{{ asmconfig }}"
     - "{{ listdisks }}"
-  when: asm_disk_management == "asmlib"
+  when: ora_disk_management == "asmlib"
   tags: asm-disks

--- a/roles/rac-gi-setup/tasks/rac-asm-create.yml
+++ b/roles/rac-gi-setup/tasks/rac-asm-create.yml
@@ -47,7 +47,7 @@
     ORACLE_SID: "{{ asm_sid }}"
     LD_LIBRARY_PATH: "{{ grid_home }}/lib:${LD_LIBRARY_PATH}"
   when:
-    - asm_disk_management == "asmlib"
+    - ora_disk_management == "asmlib"
     - created_dg is not search(item.diskgroup)
   with_items: "{{ asm_disks }}"
   register: create_dg
@@ -74,7 +74,7 @@
     ORACLE_SID: "{{ asm_sid }}"
     LD_LIBRARY_PATH: "{{ grid_home }}/lib:${LD_LIBRARY_PATH}"
   when:
-    - asm_disk_management in ["udev", "asmudev"]
+    - ora_disk_management in ["udev", "asmudev"]
     - created_dg is not search(item.diskgroup)
   with_items: "{{ asm_disks }}"
   register: create_dg

--- a/roles/rac-gi-setup/tasks/rac-gi-install.yml
+++ b/roles/rac-gi-setup/tasks/rac-gi-install.yml
@@ -97,7 +97,7 @@
   shell: |
     udevadm info --query=all --name={% if item is search('mapper') %}{{ item.blk_device }}{% else %}{{ item.first_partition_id }}{% endif %} | grep "^S: " | grep {{ path_udev }} | awk '{ print "/dev/"$2 }'
   loop: "{{ asm_disks | json_query('[?diskgroup==`' + hostvars[groups['dbasm'].0]['dg_name'] + '`].disks[*]') | list | flatten }}"
-  when: asm_disk_management in ["udev", "asmudev"]
+  when: ora_disk_management in ["udev", "asmudev"]
   register: symlink
 
 - name: rac-gi-install | Generate random password


### PR DESCRIPTION
Small change to rename the Ansible variable `asm_disk_management` to `ora_disk_management`.

While the variable name `asm_disk_management` made sense originally to differentiate between ASM disk management via UDEV vs ASMlib, it is no longer intuitive with the current version of the toolkit which supports XFS filesystems without GI or ASM (i.e `asm_disk_management=fs`).

Consequently, simply renaming all occurrences of this Ansible variable, changing the three letters "**asm**" to "**ora**".

No updates to documentation or backward compatibility should be required as this variable is used by Ansible playbooks and tasks only - it is not included in the documentation or specified in the toolkit shell scripts.

---

Verification that all occurrences are changed:

```bash
$ grep -ri asm_disk_management

$ grep -ri ora_disk_management
group_vars/all.yml:gi_install: "{{ not free_edition and not ora_disk_management == 'fs' }}"
group_vars/all.yml:ora_disk_management: "{{ lookup('env','ORA_DISK_MGMT') | lower | default('udev',true) }}"
roles/brute-ora-cleanup/tasks/main.yml:  when: ora_disk_management == "asmlib"
roles/brute-ora-cleanup/tasks/main.yml:  when: ora_disk_management == "asmlib"
roles/brute-ora-cleanup/tasks/main.yml:  when: ora_disk_management in ["udev", "asmudev"]
roles/brute-ora-cleanup/tasks/main.yml:  when: ora_disk_management in ["udev", "asmudev"]
roles/check-swlib/tasks/main.yml:  loop: "{{ (((gi_software + gi_interim_patches) if ora_disk_management != 'fs' else []) + rdbms_software) | subelements('files') }}"
roles/check-swlib/tasks/main.yml:       gi_patches | default([]) if ora_disk_management != 'fs' else
roles/common/defaults/main.yml:asm_diskstring: "{% if ora_disk_management == 'asmlib' %}ORCL:*{% else %}/dev/{{ path_udev }}/*{% endif %}"
roles/gi-setup/tasks/asm-create.yml:  when: ora_disk_management == "asmlib"
roles/gi-setup/tasks/asm-create.yml:  when: ora_disk_management in ["udev", "asmudev"]
roles/ora-host/tasks/main.yml:    msg: "ora_disk_management is set to {{ ora_disk_management }}"
roles/ora-host/tasks/main.yml:    - ora_disk_management != "fs"
roles/ora-host/tasks/main.yml:  when: ora_disk_management != "fs"
roles/ora-host/tasks/main.yml:  when: ora_disk_management != "fs"
roles/ora-host/tasks/main.yml:    - ora_disk_management in ["udev", "asmudev"]
roles/ora-host/tasks/main.yml:  when: ora_disk_management in ["udev", "asmudev"]
roles/ora-host/tasks/main.yml:  when: ora_disk_management == "asmlib"
roles/ora-host/tasks/main.yml:  when: ora_disk_management == "asmlib"
roles/ora-host/tasks/main.yml:  when: ora_disk_management == "asmlib"
roles/ora-host/tasks/main.yml:  when: ora_disk_management == "asmlib"
roles/ora-host/tasks/main.yml:  when: ora_disk_management == "asmlib"
roles/ora-host/tasks/main.yml:  when: ora_disk_management == "asmlib"
roles/ora-host/tasks/main.yml:  when: ora_disk_management == "asmlib"
roles/rac-gi-setup/tasks/rac-asm-create.yml:    - ora_disk_management == "asmlib"
roles/rac-gi-setup/tasks/rac-asm-create.yml:    - ora_disk_management in ["udev", "asmudev"]
roles/rac-gi-setup/tasks/rac-gi-install.yml:  when: ora_disk_management in ["udev", "asmudev"]
```
