### PR TITLE
Refactor the GCS download/transfer roles into a more logical and better flowing set of tasks

### DIFF
--- a/roles/swlib/tasks/build_file_list.yml
+++ b/roles/swlib/tasks/build_file_list.yml
@@ -100,5 +100,5 @@
       opatch_file_list: "{{ opatch_file_list }}"
       base_sw_file_list: "{{ base_sw_file_list }}"
       patch_file_list: "{{ patch_file_list }}"
-    verbosity: 0
+    verbosity: 1
   when: not free_edition

--- a/roles/swlib/tasks/gcsdirect.yml
+++ b/roles/swlib/tasks/gcsdirect.yml
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 ---
-- name: gcsdirect | Copy OPatch (always)
+- name: gcsdirect | Copy OPatch
   shell: |
     set -o pipefail
-    gcloud storage cp gs://{{ swlib_mount_src }}/{{ item }} "{{ swlib_path }}/{{ item }}"
+    gcloud storage cp "gs://{{ swlib_mount_src }}/{{ item }}" "{{ swlib_path }}/{{ item }}"
   register: shell_result
   args:
     executable: /bin/bash
@@ -26,13 +26,13 @@
 - name: gcsdirect | Copy base software files using file_name or alt_name
   shell: |
     set -o pipefail
-    if gcloud storage ls gs://{{ swlib_mount_src }}/{{ item.file_name }} >/dev/null 2>&1; then
+    if gcloud storage ls "gs://{{ swlib_mount_src }}/{{ item.file_name }}" >/dev/null 2>&1; then
       f_name="{{ item.file_name }}"
     else
       f_name="{{ item.alt_name | default('x') }}"
     fi
     if ! unzip -l "{{ swlib_path }}/${f_name}"; then
-      gcloud storage cp gs://{{ swlib_mount_src }}/${f_name} "{{ swlib_path }}/{{ item.file_name }}"
+      gcloud storage cp "gs://{{ swlib_mount_src }}/${f_name}" "{{ swlib_path }}/{{ item.file_name }}"
     fi
   register: shell_result
   args:
@@ -45,15 +45,13 @@
     set -o pipefail
     if ! unzip -l "{{ swlib_path }}/{{ item }}"
       then
-        gcloud storage cp gs://{{ swlib_mount_src }}/{{ item }} "{{ swlib_path }}/{{ item }}"
+        gcloud storage cp "gs://{{ swlib_mount_src }}/{{ item }}" "{{ swlib_path }}/{{ item }}"
     fi
   register: shell_result
   args:
     executable: /bin/bash
   with_items: "{{ patch_file_list | unique }}"
   changed_when: "'Date    Time    Name' not in shell_result.stdout"
-
-################################################################################
 
 - name: gcsdirect | Download or copy RPM software from GCS to target instance
   shell: |
@@ -63,7 +61,7 @@
       if [[ "{{ f.name }}" == https://*oracle.com/* || "{{ f.name }}" == http://*oracle.com/* ]]; then
         curl --location --silent --connect-timeout 20 --fail -o "{{ swlib_path }}/{{ f.name | basename }}" "{{ f.name }}" && echo "File downloaded"
       else
-        gcloud storage cp gs://{{ swlib_mount_src }}/{{ f.name }} "{{ swlib_path }}/{{ f.name }}" && echo "File copied"
+        gcloud storage cp "gs://{{ swlib_mount_src }}/{{ f.name }}" "{{ swlib_path }}/{{ f.name }}" && echo "File copied"
       fi
     fi
     {% endfor %}

--- a/roles/swlib/tasks/gcstransfer.yml
+++ b/roles/swlib/tasks/gcstransfer.yml
@@ -17,10 +17,10 @@
   set_fact:
     ssh_cmd: "ssh -i {{ ansible_ssh_private_key_file }} {{ ansible_ssh_extra_args }} {{ ansible_ssh_user }}@{{ ansible_ssh_host }}"
 
-- name: gcstransfer | Transfer OPatch (always)
+- name: gcstransfer | Transfer OPatch
   shell: |
     set -o pipefail
-    gcloud storage cat gs://{{ swlib_mount_src }}/{{ item }} | {{ ssh_cmd }} "cat > {{ swlib_path }}/{{ item }}"
+    gcloud storage cat "gs://{{ swlib_mount_src }}/{{ item }}" | {{ ssh_cmd }} "cat > \"{{ swlib_path }}/{{ item }}\""
   register: shell_result
   args:
     executable: /bin/bash
@@ -31,13 +31,13 @@
 - name: gcstransfer | Transfer base software files using file_name or alt_name
   shell: |
     set -o pipefail
-    if gcloud storage ls gs://{{ swlib_mount_src }}/{{ item.file_name }} >/dev/null 2>&1; then
+    if gcloud storage ls "gs://{{ swlib_mount_src }}/{{ item.file_name }}" >/dev/null 2>&1; then
       f_name="{{ item.file_name }}"
     else
       f_name="{{ item.alt_name | default('x') }}"
     fi
-    if ! {{ ssh_cmd }} unzip -l "{{ swlib_path }}/${f_name}"; then
-      gcloud storage cat gs://"{{ swlib_mount_src }}"/"${f_name}" | {{ ssh_cmd }} "cat > {{ swlib_path }}/{{ item.file_name }}"
+    if ! {{ ssh_cmd }} "unzip -l \"{{ swlib_path }}/${f_name}\""; then
+      gcloud storage cat "gs://{{ swlib_mount_src }}/${f_name}" | {{ ssh_cmd }} "cat > \"{{ swlib_path }}/{{ item.file_name }}\""
     fi
   register: shell_result
   args:
@@ -49,8 +49,8 @@
 - name: gcstransfer | Transfer patch files
   shell: |
     set -o pipefail
-    if ! {{ ssh_cmd }} unzip -l "{{ swlib_path }}/{{ item }}"; then
-      gcloud storage cat gs://{{ swlib_mount_src }}/{{ item }} | {{ ssh_cmd }} "cat > {{ swlib_path }}/{{ item }}"
+    if ! {{ ssh_cmd }} "unzip -l \"{{ swlib_path }}/{{ item }}\""; then
+      gcloud storage cat "gs://{{ swlib_mount_src }}/{{ item }}" | {{ ssh_cmd }} "cat > \"{{ swlib_path }}/{{ item }}\""
     fi
   register: shell_result
   args:
@@ -59,20 +59,15 @@
   changed_when: "'Date    Time    Name' not in shell_result.stdout"
   delegate_to: localhost
 
-################################################################################
-
 - name: gcstransfer | Download or transfer RPM software from GCS to target instance
   shell: |
     set -o pipefail
     {% for f in item.files %}
-    if ! ssh -i {{ ansible_ssh_private_key_file }} {{ ansible_ssh_extra_args }} {{ ansible_ssh_user }}@{{ ansible_ssh_host }} \
-      "rpm -qp {{ swlib_path }}/{{ f.name | basename }}"; then
+    if ! {{ ssh_cmd }} "rpm -qp \"{{ swlib_path }}/{{ f.name | basename }}\""; then
       if [[ "{{ f.name }}" == https://*oracle.com/* || "{{ f.name }}" == http://*oracle.com/* ]]; then
-        ssh -i {{ ansible_ssh_private_key_file }} {{ ansible_ssh_extra_args }} {{ ansible_ssh_user }}@{{ ansible_ssh_host }} \
-          curl --location --silent --connect-timeout 20 --fail -o "{{ swlib_path }}/{{ f.name | basename }}" "{{ f.name }}" && echo "File downloaded"
+        {{ ssh_cmd }} "curl --location --silent --connect-timeout 20 --fail -o \"{{ swlib_path }}/{{ f.name | basename }}\" \"{{ f.name }}\" && echo \"File downloaded\""
       else
-        gcloud storage cat gs://"{{ swlib_mount_src }}"/"{{ f.name }}" | ssh -i {{ ansible_ssh_private_key_file }} {{ ansible_ssh_extra_args }} \
-          {{ ansible_ssh_user }}@{{ ansible_ssh_host }} "cat > {{ swlib_path }}/{{ f.name }}" && echo "File copied"
+        gcloud storage cat "gs://{{ swlib_mount_src }}/{{ f.name }}" | {{ ssh_cmd }} "cat > \"{{ swlib_path }}/{{ f.name }}\" && echo \"File copied\""
       fi
     fi
     {% endfor %}

--- a/roles/swlib/tasks/main.yml
+++ b/roles/swlib/tasks/main.yml
@@ -42,12 +42,12 @@
 
 - name: swlib | Determine required installation files
   include_tasks: build_file_list.yml
-  when: swlib_mount_type not in ["gcsfuse","nfs"]
+  when: swlib_mount_type in ["gcs", "gcsdirect", "gcstransfer"]
 
 - name: swlib | Copy files from GCS directly on the Managed Host instance
   include_tasks: gcsdirect.yml
-  when: swlib_mount_type in ["gcsdirect", "gcs"] and gcloud_found is defined and gcloud_found.stdout == "0"
+  when: swlib_mount_type in ["gcs", "gcsdirect"] and gcloud_found is defined and gcloud_found.stdout == "0"
 
 - name: swlib | Use the Ansible Control Node to transfer files from GCS to the Managed Host instance
   include_tasks: gcstransfer.yml
-  when: swlib_mount_type == "gcstransfer" or (swlib_mount_type in ["gcsdirect", "gcs"] and gcloud_found.stdout | default("1") != "0")
+  when: swlib_mount_type == "gcstransfer" or gcloud_found is not defined or (gcloud_found is defined and gcloud_found.stdout != "0")


### PR DESCRIPTION
## Change Description:

Re-organize tasks and task files related to GCS procurement of media to provide a more logical, less redundant, and easier to follow set of organized steps (tasks).

## Solution Overview:

> **IMPORTANT NOTE TO REVIEWERS:** Might be easier to first review by looking at the re-factored task files as a whole vs looking at the differences/comparison view as the changes are significant

The existing tasks for downloading the software media from GCS storage buckets are split between two, substantially similar, task files: one (`gcstransfer.yml`) that transfers the files through the Ansible control node and another (`gcsdirect.yml`) that directly downloads from the swlib if the gcloud utility is available on the managed host.

Regardless of which task file is run, the steps are confusing and redundant. Specifically:

- There are many `shell` module tasks that effectively perform the same activities on the managed host.
- There are numerous interwoven `when` keys and jinja2 filters that are exactly replicated between the two files.
- If we were to add another download mechanism (i.e. from a private repository via URL), then we would replicate the above mentioned redundancy a third time.

Solution in this change is conceptually:

1. Build three lists of software to procure: one for the OPatch file (as it needs to be treated slightly differently as will be explained), one for base software (RDBMS and if required GI) which includes a primary file name and an alternate, and finally one for required patches. The content of each list will vary based on the chosen Oracle version and type of installation (i.e. full or `--no-patch` or `--ora-release base`).
2. Procure all of the files in one step per list: OPatch files are "always" re-downloaded (to ensure that the latest version is present/used), base software could be sourced from either the file name or alternate name, and patches are simply sourced by their name. The latter two, only re-sourced if they don't already exist.

Step 1 is performed in a new task file called `build_file_list.yml` that can be used under multiple conditions (such as direct download, or transfer through the control node). Then the `gcsdirect.yml` and `gcstransfer.yml` files are significantly simpler to follow and more organized with just three core tasks for the various procurement logic (with a fourth, simple, `set_fact` module in the latter) handling step 2.

> **NOTE:** Free edition software procurement is still treated separately via an additional and **unchanged** task in each file - this could possibly be simplified further in a separate and future PR.

## Test Results:

Test runs of various permutations with `verbosity: 1` for the `build_file_list | Display files lists` task:

- [Full typical install with Oracle 18c](https://gist.github.com/simonpane/19bed308fae316ccd881c9e6c989f1dc)
- [Full typical install with Oracle 21c](https://gist.github.com/simonpane/085f0c4dd5b49461e5eb046164be23a0)
- [Full typical install with Oracle 19c](https://gist.github.com/simonpane/521c3a273b779777fb81d9a9e04597be)
- [Full day-2 patched install with Oracle 19c](https://gist.github.com/simonpane/85823a105f5600753fb20db1a03219ad)
- [Full typical install with Oracle 19c using the "base" option](https://gist.github.com/simonpane/2935d7ef95751aa319a7df5d5024fa1d)
- [Free Edition install](https://gist.github.com/simonpane/aff9ea2ae10703dce18d4797a63ba921)
- [Full typical install with Oracle 19c using Ansible 2.9](https://gist.github.com/simonpane/3361b7393d0818b8ff8223bd6dff1297)
