### PR TITLE
Include `/usr/local/bin` in PATH variable in backup scripts to prevent cron-run failures

### DIFF
--- a/roles/db-backups/templates/rman_arch_backup.sh.j2
+++ b/roles/db-backups/templates/rman_arch_backup.sh.j2
@@ -55,8 +55,8 @@ logfile="${log_dir}/rman_${start_ts}_${type}.log"
 #
 # Set the Oracle env
 #
-export ORACLE_SID="${ora_inst_name}"
-source oraenv <<<"${ora_inst_name}" >/dev/null 2>&1
+export PATH="/usr/local/bin:${PATH}"
+source oraenv <<<"${ora_inst_name}" >/dev/null 2>&1 || exit 1
 #
 # RMAN backup
 #

--- a/roles/db-backups/templates/rman_delete_arch.sh.j2
+++ b/roles/db-backups/templates/rman_delete_arch.sh.j2
@@ -41,8 +41,8 @@ logfile="${log_dir}/rman_${start_ts}_${type}.log"
 #
 # Set the Oracle env
 #
-export ORACLE_SID="${ora_inst_name}"
-source oraenv <<<"${ora_inst_name}" >/dev/null 2>&1
+export PATH="/usr/local/bin:${PATH}"
+source oraenv <<<"${ora_inst_name}" >/dev/null 2>&1 || exit 1
 #
 # RMAN archivelog deletion
 #

--- a/roles/db-backups/templates/rman_full_backup.sh.j2
+++ b/roles/db-backups/templates/rman_full_backup.sh.j2
@@ -60,8 +60,8 @@ logfile="${log_dir}/rman_${start_ts}_${type}.log"
 #
 # Set the Oracle env
 #
-export ORACLE_SID="${ora_inst_name}"
-source oraenv <<<"${ora_inst_name}" >/dev/null 2>&1
+export PATH="/usr/local/bin:${PATH}"
+source oraenv <<<"${ora_inst_name}" >/dev/null 2>&1 || exit 1
 #
 # RMAN backup
 #


### PR DESCRIPTION
## Change Description:

Add critical fix to backup script's call of `oraenv` which is currently causing them to all fail when run from cron.

## Solution Overview:

The backup scripts copied to the managed host target and scheduled via cron run successfully from the Ansible toolkit but fail (constantly) when run from cron.

The problem is that when run from the Ansible playbook, the `PATH` variable is properly set and is properly finding `oraenv`. However, when run from a cron entry, `oraenv` is not being found and the `ORACLE_HOME` environment variable is constantly not being set. The result is that the script cannot find the actual `rman` executable and fails every time it is run from a cron.

This issue is evident from the `/var/log/cron` file which shows entries such as:

```plaintext
Sep 15 13:30:01 server CROND[57953]: (oracle) CMD (/home/oracle/scripts/rman_arch_backup.sh prod1 2 7)
Sep 15 13:30:01 server CROND[57937]: (oracle) CMDOUT (/home/oracle/scripts/rman_arch_backup.sh: line 63: /bin/rman: No such file or directory)
```

The bash shell script is running `${ORACLE_HOME}/bin/rman` and since the environment variables are not set, `${ORACLE_HOME}` is undefined/empty string.

Solution is to set the `${PATH}` variable to include `/usr/local/bin`. This is preferable to the alternative of using a fully qualified `/usr/local/bin/oraenv` call as `oraenv` itself calls other executables in the user binary directory such as `dbhome`. Also, explicitly setting the `ORACLE_SID` environment variable beforehand is unnecessary as the `oraenv` script will set it (and `ORACLE_SID` is not explicitly used anywhere else in the bash scripts and further, `ORAENV_ASK` is not set/used).

Additionally, a small enhancement is to fail the script should the oraenv command fail. (Hopefully system monitoring tools outside of the scope of this toolkit detects and alerts to failed crons.)