### PR TITLE
Collect usage metrics for Terraform deployments via workload agent

### DIFF
--- a/roles/workload-agent/tasks/main.yml
+++ b/roles/workload-agent/tasks/main.yml
@@ -17,6 +17,32 @@
   include_tasks:
     file: install.yml
   tags: workload-agent
+  
+- name: Find the exact path of the installed agent executable
+  ansible.builtin.shell:
+    # Query the RPM database for the package and grep for the main executable
+    # The '$' at the end ensures we get the main binary, not a helper script
+    cmd: "rpm -ql google-cloud-workload-agent | grep '/bin/google-cloud-workload-agent$'"
+  register: agent_exe_path
+  changed_when: false
+  ignore_errors: true
+  tags: workload-agent
+  when: ansible_env.INSTALL_WORKLOAD_AGENT is defined and ansible_env.INSTALL_WORKLOAD_AGENT == "true"
+
+- name: Log workload agent installation
+  ansible.builtin.shell:
+    cmd: "{{ agent_exe_path.stdout }} logusage -s ACTION -a 5"
+  register: log_result
+  changed_when: false
+  ignore_errors: true
+  tags: workload-agent
+  when:
+    - ansible_env.INSTALL_WORKLOAD_AGENT is defined
+    - ansible_env.INSTALL_WORKLOAD_AGENT == "true"
+    - agent_exe_path.rc is defined
+    - agent_exe_path.rc == 0
+    - agent_exe_path.stdout is defined
+    - agent_exe_path.stdout != ""
 
 - name: Create a database user for the Google Cloud Agent for Compute Workloads to collect Oracle metrics
   include_tasks:

--- a/roles/workload-agent/tasks/main.yml
+++ b/roles/workload-agent/tasks/main.yml
@@ -18,31 +18,13 @@
     file: install.yml
   tags: workload-agent
   
-- name: Find the exact path of the installed agent executable
-  ansible.builtin.shell:
-    # Query the RPM database for the package and grep for the main executable
-    # The '$' at the end ensures we get the main binary, not a helper script
-    cmd: "rpm -ql google-cloud-workload-agent | grep '/bin/google-cloud-workload-agent$'"
-  register: agent_exe_path
-  changed_when: false
-  ignore_errors: true
-  tags: workload-agent
-  when: ansible_env.INSTALL_WORKLOAD_AGENT is defined and ansible_env.INSTALL_WORKLOAD_AGENT == "true"
-
 - name: Log workload agent installation
   ansible.builtin.shell:
-    cmd: "{{ agent_exe_path.stdout }} logusage -s ACTION -a 5"
+    cmd: "/usr/bin/google_cloud_workload_agent logusage -s ACTION -a 5"
   register: log_result
   changed_when: false
   ignore_errors: true
   tags: workload-agent
-  when:
-    - ansible_env.INSTALL_WORKLOAD_AGENT is defined
-    - ansible_env.INSTALL_WORKLOAD_AGENT == "true"
-    - agent_exe_path.rc is defined
-    - agent_exe_path.rc == 0
-    - agent_exe_path.stdout is defined
-    - agent_exe_path.stdout != ""
 
 - name: Create a database user for the Google Cloud Agent for Compute Workloads to collect Oracle metrics
   include_tasks:


### PR DESCRIPTION
Adds new Ansible tasks to find the google-cloud-workload-agent executable and run the logusage command.

These logging tasks are made conditional and will only run if the agent installation is requested. This is done by checking the ansible_env.INSTALL_WORKLOAD_AGENT variable, which is already exported by the install-oracle.sh script.

Buganizer: b/427723342