### PR TITLE
Add .tool-versions to declare runtime dependencies for SBOM

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,9 @@
-# This file pins the required versions of runtime dependencies for the oracle-toolkit.
-# It is used by the build script to generate an accurate SBOM and ensures a
-# consistent environment for developers.
+# This file pins the required versions of runtime dependencies for the oracle-toolkit 
+# to ensure a consistent developer environment and to generate an accurate SBOM.
+#
+# The Python version specified is the minimum required by the pinned Ansible version, 
+# as per the Ansible support matrix:
+# https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
 
-ansible 2.16.5
-python 3.9.2
+ansible 2.9
+python 3.5

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,6 @@
+# This file pins the required versions of runtime dependencies for the oracle-toolkit.
+# It is used by the build script to generate an accurate SBOM and ensures a
+# consistent environment for developers.
+
+ansible 2.16.5
+python 3.9.2

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -164,7 +164,7 @@ proxy_setup: "{{ lookup('env','ORA_PROXY_SETUP') | lower | default('false',true)
 u01_lun: "{{ lookup('env','ORA_U01_LUN') | lower | default('',true) }}"
 
 #  Environment and infrastructure values (requirements) used for readiness checks
-minimum_ansible_version: "{{ lookup('file', playbook_dir + '/../.tool-versions') | regex_search('^ansible\\s+(.*)$', '\\1') | first }}"
+minimum_ansible_version: 2.9
 os_supported_architecture: "x86_64"
 os_family_supported: "RedHat"
 os_min_supported_version: "{% if free_edition %}8{% else %}7.3{% endif %}"

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -164,7 +164,7 @@ proxy_setup: "{{ lookup('env','ORA_PROXY_SETUP') | lower | default('false',true)
 u01_lun: "{{ lookup('env','ORA_U01_LUN') | lower | default('',true) }}"
 
 #  Environment and infrastructure values (requirements) used for readiness checks
-minimum_ansible_version: 2.9
+minimum_ansible_version: "{{ lookup('file', playbook_dir + '/../.tool-versions') | regex_search('^ansible\\s+(.*)$', '\\1') | first }}"
 os_supported_architecture: "x86_64"
 os_family_supported: "RedHat"
 os_min_supported_version: "{% if free_edition %}8{% else %}7.3{% endif %}"

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -164,6 +164,8 @@ proxy_setup: "{{ lookup('env','ORA_PROXY_SETUP') | lower | default('false',true)
 u01_lun: "{{ lookup('env','ORA_U01_LUN') | lower | default('',true) }}"
 
 #  Environment and infrastructure values (requirements) used for readiness checks
+# NOTE: If you update minimum_ansible_version, please also update .tool-versions.
+# The .tool-versions file is the source of truth for SBOM generation.
 minimum_ansible_version: 2.9
 os_supported_architecture: "x86_64"
 os_family_supported: "RedHat"


### PR DESCRIPTION
This change adds a .tool-versions file to declare and pin the specific versions of runtime dependencies like Ansible and Python. This allows the build script to generate a more accurate SBOM by reading the required versions directly from this file.