### PR TITLE
Add expiration time for OS login keys

### DIFF
--- a/terraform/scripts/setup.sh.tpl
+++ b/terraform/scripts/setup.sh.tpl
@@ -192,6 +192,13 @@ for node in $(echo '${database_vm_nodes_json}' | jq -c '.[] | select(.role == "p
     exit 1
   }
 
+  if [[ -f "/root/.ssh/google_compute_engine.pub" ]]; then
+    echo "Setting expiration on SSH key"
+    if ! gcloud --quiet compute os-login ssh-keys update --key-file=/root/.ssh/google_compute_engine.pub --ttl=24h; then
+      echo "WARNING: Failed to set expiration for SSH key."
+    fi
+  fi
+
     echo "Configuring PRIMARY node: $node_name, IP: $node_ip, Zone: $node_zone"
     bash install-oracle.sh \
     --cluster-type NONE \


### PR DESCRIPTION
Although we have a cleanup routing to attempt to clear out old, unnecessary OS login SSH keys, it requires the cleanup handler to be able to run, which doesn't always happen, especially when a test is pre-empted.

This change explicitly sets a 24-hour key expiration to automatically clean out keys that the cleanup might not catch.

Internal reference: b/448418410

Presubmit logs:  https://oss.gprow.dev/view/gs/gcp-oracle-prow-bucket/pr-logs/pull/google_oracle-toolkit/364/oracle-toolkit-install-free-edition-on-gcp/1973112242173906944

```
2025-09-30 19:51:17	Setting expiration on SSH key
2025-09-30 19:51:18	expirationTimeUsec: '1759348278113529'
2025-09-30 19:51:18	fingerprint: 4f443e3e05c7ed3296bb14d6d5a4aee24ecf900a45d0ba15b27cde45a16f50f4
```