### PR TITLE
Relocate presubmit tests to us-east1

### DIFF
--- a/presubmit_tests/26ai-dg-on-gcp.sh
+++ b/presubmit_tests/26ai-dg-on-gcp.sh
@@ -6,7 +6,7 @@ source presubmit_tests/infra-manager-lib.sh || {
 instance_name="github-presubmit-26ai-dg-${BUILD_ID}"
 deployment_name="presubmit-26ai-dg-${BUILD_ID}"
 tfvars_file="./presubmit_tests/26ai-dg.tfvars"
-location="us-central1"
+location="us-east1"
 setup_vars
 apply_deployment
 watch_logs

--- a/presubmit_tests/26ai-dg.tfvars
+++ b/presubmit_tests/26ai-dg.tfvars
@@ -62,6 +62,6 @@ enable_ar_repo = true
 # TLS / SSL Configuration
 # -----------------------------------------------------------------------------
 enable_tls      = true
-cas_pool_id     = "projects/gcp-oracle-benchmarks/locations/us-east1/caPools/presubmit-ca-pool"
+cas_pool_id     = "projects/gcp-oracle-benchmarks/locations/us-central1/caPools/presubmit-ca-pool"
 dns_zone_name   = "presubmit-private-zone"
 dns_domain_name = "presubmit.internal."

--- a/presubmit_tests/26ai-dg.tfvars
+++ b/presubmit_tests/26ai-dg.tfvars
@@ -34,10 +34,10 @@ machine_type = "n4-standard-2"
 boot_disk_type = "hyperdisk-balanced"
 boot_disk_size_gb = "20"
 swap_disk_size_gb = "8"
-zone1 = "us-central1-b"
-zone2 = "us-central1-c"
-subnetwork1 = "projects/gcp-oracle-benchmarks/regions/us-central1/subnetworks/github-presubmit-tests-us-central1"
-subnetwork2 = "projects/gcp-oracle-benchmarks/regions/us-central1/subnetworks/github-presubmit-tests-us-central1"
+zone1 = "us-east1-c"
+zone2 = "us-east1-d"
+subnetwork1 = "projects/gcp-oracle-benchmarks/regions/us-east1/subnetworks/github-presubmit-tests-us-east1"
+subnetwork2 = "projects/gcp-oracle-benchmarks/regions/us-east1/subnetworks/github-presubmit-tests-us-east1"
 oracle_home_disk = {
   size_gb = 50
 }
@@ -62,6 +62,6 @@ enable_ar_repo = true
 # TLS / SSL Configuration
 # -----------------------------------------------------------------------------
 enable_tls      = true
-cas_pool_id     = "projects/gcp-oracle-benchmarks/locations/us-central1/caPools/presubmit-ca-pool"
+cas_pool_id     = "projects/gcp-oracle-benchmarks/locations/us-east1/caPools/presubmit-ca-pool"
 dns_zone_name   = "presubmit-private-zone"
 dns_domain_name = "presubmit.internal."

--- a/presubmit_tests/data-guard-on-gcp.sh
+++ b/presubmit_tests/data-guard-on-gcp.sh
@@ -21,7 +21,7 @@ source presubmit_tests/infra-manager-lib.sh || {
 instance_name="github-presubmit-dg-${BUILD_ID}"
 deployment_name="presubmit-dg-${BUILD_ID}"
 tfvars_file="./presubmit_tests/data-guard.tfvars"
-location="us-central1"
+location="us-east1"
 setup_vars
 apply_deployment
 watch_logs

--- a/presubmit_tests/data-guard.tfvars
+++ b/presubmit_tests/data-guard.tfvars
@@ -34,10 +34,10 @@ machine_type = "n4-standard-2"
 boot_disk_type = "hyperdisk-balanced"
 boot_disk_size_gb = "20"
 swap_disk_size_gb = "8"
-zone1 = "us-central1-b"
-zone2 = "us-central1-c"
-subnetwork1 = "projects/gcp-oracle-benchmarks/regions/us-central1/subnetworks/github-presubmit-tests-us-central1"
-subnetwork2 = "projects/gcp-oracle-benchmarks/regions/us-central1/subnetworks/github-presubmit-tests-us-central1"
+zone1 = "us-east1-c"
+zone2 = "us-east1-d"
+subnetwork1 = "projects/gcp-oracle-benchmarks/regions/us-east1/subnetworks/github-presubmit-tests-us-east1"
+subnetwork2 = "projects/gcp-oracle-benchmarks/regions/us-east1/subnetworks/github-presubmit-tests-us-east1"
 oracle_home_disk = {
   size_gb = 50
 }

--- a/presubmit_tests/free-edition-on-gcp.sh
+++ b/presubmit_tests/free-edition-on-gcp.sh
@@ -21,7 +21,7 @@ source presubmit_tests/infra-manager-lib.sh || {
 instance_name="github-presubmit-free-${BUILD_ID}"
 deployment_name="presubmit-free-${BUILD_ID}"
 tfvars_file="./presubmit_tests/free-edition.tfvars"
-location="us-central1"
+location="us-east1"
 
 setup_vars
 apply_deployment

--- a/presubmit_tests/free-edition.tfvars
+++ b/presubmit_tests/free-edition.tfvars
@@ -34,8 +34,8 @@ machine_type = "n4-standard-2"
 boot_disk_type = "hyperdisk-balanced"
 boot_disk_size_gb = "30"
 swap_disk_size_gb = "8"
-zone1 = "us-central1-b"
-subnetwork1 = "projects/gcp-oracle-benchmarks/regions/us-central1/subnetworks/github-presubmit-tests-us-central1"
+zone1 = "us-east1-c"
+subnetwork1 = "projects/gcp-oracle-benchmarks/regions/us-east1/subnetworks/github-presubmit-tests-us-east1"
 oracle_home_disk = {
   size_gb = 50
 }


### PR DESCRIPTION
We're seeing consistent failures in us-central1-c due to stockouts of N4 VM shapes.  This change updates the GCP tests to run on `us-east1-c` and `us-east1-d` instead.