### PR TITLE
Add commit signing to the contributing.md doc

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -19,12 +19,29 @@ You generally only need to submit a CLA once, so if you've already submitted one
 (even if it was for a different project), you probably don't need to do it
 again.
 
-## Code reviews
+## Code Reviews
 
 All submissions, including submissions by project members, require review. We
 use GitHub pull requests for this purpose. Consult
 [GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
 information on using pull requests.
+
+## Commit Signing
+
+Please sign commits for project contributions.  More details can be found on the
+[GitHub Docs: Managing commit signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification)
+page.
+
+Once you have key signing configured, you can enable automatic signing for all
+commits in your local repositories with:
+
+```bash
+git config --global commit.gpgsign true
+```
+
+We plan to enforce this requirement on the main branch beginning 2026-06-01.
+Pull requests with unsigned commits will be blocked from merging after this
+date.
 
 ## Community Guidelines
 


### PR DESCRIPTION
To improve traceability and to help support vendor tooling, we'll be mandating commit signing in the project.