### PR TITLE
Fix Oracle 12.1 installations on EL8 hosts

### DIFF
--- a/roles/compatibility-tests/tasks/main.yml
+++ b/roles/compatibility-tests/tasks/main.yml
@@ -26,15 +26,15 @@
 
 - name: Get base and latest releases
   block:
-    - name: Create a list of releases for the target base version | not 11g
+    - name: Create a list of releases for the target base version | 12.2+
       ansible.builtin.set_fact:
         releases_for_base: "{{ rdbms_patches | selectattr('base', 'match', oracle_ver_base) | selectattr('category', 'eq', 'DB_RU') | map(attribute='release') | list }}"
-      when: oracle_ver_base is not match('^11.2.*')
+      when: not oracle_ver_base is match('^(11\.2|12\.1).*')
 
-    - name: Create a list of releases for the target base version | 11g
+    - name: Create a list of releases for the target base version | 11g / 12.1
       ansible.builtin.set_fact:
         releases_for_base: "{{ rdbms_patches | selectattr('base', 'match', oracle_ver_base) | selectattr('category', 'eq', 'PSU_Combo') | map(attribute='release') | list }}"
-      when: oracle_ver_base is match('^11.2.*')
+      when: oracle_ver_base is match('^(11\.2|12\.1).*')
 
     - name: Set lowest and highest release from the list
       ansible.builtin.set_fact:

--- a/roles/ora-host/defaults/main.yml
+++ b/roles/ora-host/defaults/main.yml
@@ -69,6 +69,8 @@ oracle_required_rpms_el8:
   - compat-openssl10
   - elfutils-libelf
   - fontconfig
+  - gcc
+  - gcc-c++
   - libasan
   - libibverbs
   - liblsan
@@ -86,6 +88,8 @@ oracle_required_rpms_el9:
   - compat-openssl11
   - elfutils-libelf
   - fontconfig
+  - gcc
+  - gcc-c++
   - glibc-headers
   - grub2-tools
   - libasan

--- a/roles/ora-host/tasks/main.yml
+++ b/roles/ora-host/tasks/main.yml
@@ -114,6 +114,17 @@
     - not (ansible_distribution == 'RedHat' and ansible_distribution_major_version | int == 7)
   tags: os-packages
 
+- name: Create libcap.so.1 symlink for Oracle compatibility on EL8/EL9
+  file:
+    src: "/usr/lib64/libcap.so.2"
+    dest: "/usr/lib64/libcap.so.1"
+    state: link
+  when:
+    - ansible_os_family == 'RedHat'
+    - ansible_distribution_major_version | int in [8, 9]
+    - oracle_ver is version('12.2.0.1.0', '<')
+  tags: os-packages
+
 - name: Skip Google Cloud CLI installation if non-RHEL OS detected
   debug:
     msg: "Non-RHEL OS detected. Skipping the installation of Google Cloud CLI"

--- a/roles/rdbms-setup/templates/db_install.rsp.sh.j2
+++ b/roles/rdbms-setup/templates/db_install.rsp.sh.j2
@@ -25,14 +25,14 @@ sed -i 's~^[# ]*INVENTORY_LOCATION=.*$~INVENTORY_LOCATION={{ oracle_inventory }}
 sed -i 's~^[# ]*ORACLE_HOME=.*$~ORACLE_HOME={{ oracle_home }}~' "$RSP_DEST"
 sed -i 's~^[# ]*ORACLE_BASE=.*$~ORACLE_BASE={{ oracle_base }}~' "$RSP_DEST"
 
-# 3. Comprehensive OS Group Mapping for 26ai (Required for INS-35344)
-# Targets both the new 26ai keys (OSDBA, etc.) and legacy keys (OSDBA_GROUP)
-sed -i 's~^[# ]*\(oracle.install.db.OSDBA_GROUP\|OSDBA\)=.*$~\1=dba~' "$RSP_DEST"
-sed -i 's~^[# ]*\(oracle.install.db.OSOPER_GROUP\|OSOPER\)=.*$~\1=dba~' "$RSP_DEST"
-sed -i 's~^[# ]*\(oracle.install.db.OSBACKUPDBA_GROUP\|OSBACKUPDBA\)=.*$~\1=dba~' "$RSP_DEST"
-sed -i 's~^[# ]*\(oracle.install.db.OSDGDBA_GROUP\|OSDGDBA\)=.*$~\1=dba~' "$RSP_DEST"
-sed -i 's~^[# ]*\(oracle.install.db.OSKMDBA_GROUP\|OSKMDBA\)=.*$~\1=dba~' "$RSP_DEST"
-sed -i 's~^[# ]*\(oracle.install.db.OSRACDBA_GROUP\|OSRACDBA\)=.*$~\1=dba~' "$RSP_DEST"
+# 3. Comprehensive OS Group Mapping (Handles variants with/without "OS" prefixes)
+# Targets: oracle.install.db.DBA_GROUP, oracle.install.db.OSDBA_GROUP, and OSDBA
+sed -i 's~^[# ]*\(oracle.install.db.\(OS\)\?DBA_GROUP\|OSDBA\)=.*$~\1=dba~' "$RSP_DEST"
+sed -i 's~^[# ]*\(oracle.install.db.\(OS\)\?OPER_GROUP\|OSOPER\)=.*$~\1=dba~' "$RSP_DEST"
+sed -i 's~^[# ]*\(oracle.install.db.\(OS\)\?BACKUPDBA_GROUP\|OSBACKUPDBA\)=.*$~\1=dba~' "$RSP_DEST"
+sed -i 's~^[# ]*\(oracle.install.db.\(OS\)\?DGDBA_GROUP\|OSDGDBA\)=.*$~\1=dba~' "$RSP_DEST"
+sed -i 's~^[# ]*\(oracle.install.db.\(OS\)\?KMDBA_GROUP\|OSKMDBA\)=.*$~\1=dba~' "$RSP_DEST"
+sed -i 's~^[# ]*\(oracle.install.db.\(OS\)\?RACDBA_GROUP\|OSRACDBA\)=.*$~\1=dba~' "$RSP_DEST"
 
 # 4. Security and Support Updates
 sed -i 's~^[# ]*SECURITY_UPDATES_VIA_MYORACLESUPPORT=.*$~SECURITY_UPDATES_VIA_MYORACLESUPPORT=false~' "$RSP_DEST"

--- a/validate-config.yml
+++ b/validate-config.yml
@@ -262,6 +262,15 @@
         fail_msg: "Invalid instance-hostname format."
       when: cluster_type != 'RAC'
 
+    - name: Validate hostname length for legacy Grid Infrastructure deployments
+      ansible.builtin.assert:
+        that:
+          - inventory_hostname | length <= 30
+        fail_msg: "For legacy Oracle versions (< 12.2) using Grid Infrastructure (ASM), the hostname '{{ inventory_hostname }}' must not exceed 30 characters due to OLR/ADR buffer limits. Current length: {{ inventory_hostname | length }}."
+      when:
+        - gi_install | bool
+        - oracle_ver is version('12.2.0.1.0', '<')
+
     - name: Validate instance_ip_addr
       ansible.builtin.assert:
         that:


### PR DESCRIPTION
## Description

Legacy Oracle versions `12.1` was failing to install or configure successfully on newer `RedHat` or `Oracle Linux 8 & 9` base images. This PR introduces OS compatibility workarounds, response file patching improvements, and pre-flight validations to safely restore automated legacy installations.

---

## Changes Introduced

### 1. 🛠️ OS Group Response Mapping
* **File modified:** `roles/rdbms-setup/templates/db_install.rsp.sh.j2`
* **Problem:** Legacy installers (11.2/12.1) use keys like `oracle.install.db.DBA_GROUP` instead of the newer `oracle.install.db.OSDBA_GROUP` or `OSDBA` introduced in 19c/26ai.
* **Solution:** Revised the `sed` replacement regexes to utilize `\(OS\)\?` (e.g., `oracle.install.db.\(OS\)\?DBA_GROUP\|OSDBA`). This dynamically matches and replaces all legacy and modern group options with the target group (`dba`) seamlessly.

### 2. 📦 Makefile Compiler Prerequisites
* **File modified:** `roles/ora-host/defaults/main.yml`
* **Problem:** Legacy Oracle installers perform silent binary object relinking (`clntsh`, `oracle`, `rman`, etc.) during silent installation. Modern base EL8 images omit basic compilers, causing this relinking step to fail silently.
* **Solution:** Re-added `gcc` and `gcc-c++` packages to the required OS RPM lists (`oracle_required_rpms_el8` and `oracle_required_rpms_el9`).

### 3. 🔗 Legacy Library Symlink Workaround
* **File modified:** `roles/ora-host/tasks/main.yml`
* **Problem:** The Grid Infrastructure standalone configuration tool (`roothas.pl`) relies on the legacy `libcap.so.1` shared library. This package has been deprecated and replaced by `libcap.so.2` in EL8.
* **Solution:** Added a host preparation task to dynamically create a `/usr/lib64/libcap.so.1` symbolic link pointing to the system's `libcap.so.2` library specifically for EL8/EL9 systems when deploying Oracle versions `< 12.2.0.1.0`.

### 4. 🛡️ Hostname Length Buffer Validation
* **File modified:** `validate-config.yml`
* **Problem:** Legacy Grid Infrastructure utilities (specifically `clscfg.bin` called during OLR/ADR setup in `roothas.pl`) have a strict 30-character limit on hostnames. Exceeding this limit (e.g., GCE VM names like `deployment-mfielding-ora121-1-1`, 31 chars) triggers buffer overflows, causing `clscfg.bin` to crash with a Segmentation Fault (Signal 11).
* **Solution:** Added a pre-flight assertion to validate that the `inventory_hostname` does not exceed `30` characters when Grid Infrastructure (`gi_install == true`) is enabled for legacy versions (`oracle_ver < 12.2.0.1.0`).
* **Scope:** Removing the RAC bypass and targeting `inventory_hostname` ensures this validation **automatically checks RAC nodes** (node names) as well as Single-Instance and Data Guard topologies.

### 5. 🐛 Post-Install Diagnostics Fix
* **File modified:** `roles/compatibility-tests/tasks/main.yml`
* **Problem:** The post-install validation playbook crashed due to an undefined `highest_release` variable.
* **Solution:** Fixed a bug in the `compatibility-tests` role where Oracle 12.1 lookups were routed to the `DB_RU` category instead of the correct `PSU_Combo` patch category used by legacy versions.

---

## Verification Conducted

1. **Pre-flight dry-run validation (`install-oracle.sh --validate`)**:
    * Verified that it successfully triggers a descriptive validation error on a 34-character hostname for legacy versions:
      > `For legacy Oracle versions (< 12.2) using Grid Infrastructure (ASM), the hostname 'long-hostname-thirty-one-chars-123' must not exceed 30 characters due to OLR/ADR buffer limits. Current length: 34.`
    * Verified that it safely skips/passes for standard filesystem (`fs` disk management) configurations or newer Oracle versions (`19c` / `23c`).
2. **End-to-End Single-Instance Grid/ASM deployment (`deploy-infra-manager.sh`)**:
    * Deployed Oracle 12.1 successfully on a `rhel-8` VM using a shortened, safe deployment name (`mf-ora121-s1` -> hostname `mf-ora121-s1-1`, 13 chars).
    * The entire run completed **successfully with 0 failures**:
        * Host prep, `libcap.so.1` symlink creation, and package installs succeeded.
        * `runInstaller` and `roothas.pl` (Configure HAS) finished cleanly.
        * ASM diskgroups (`DATA`, `RECO`) were successfully created.
        * `dbca` database instance creation (`orcl`) completed successfully.
        * `compatibility-tests` post-install diagnostics ran to completion with `ok=16, failed=0`.
   (Cloud logging link: https://console.corp.google.com/logs/query;query=resource.labels.instance_id%3D6888453454992337006)
3. **End-to-end filesystem deployment**
  (Cloud logging link: https://console.corp.google.com/logs/query;query=resource.labels.instance_id%3D7625367700073701423)

