### PR TITLE
fix(presubmit): resolve gcloud logging tail crash loop

### DIFF
--- a/presubmit_tests/infra-manager-lib.sh
+++ b/presubmit_tests/infra-manager-lib.sh
@@ -25,11 +25,10 @@ setup_vars() {
     echo "\$deployment_name is missing." >&2
     exit 1
   fi
-  apk add --no-cache zip curl py3-pip expect || exit 1
+  apk add --no-cache zip curl expect || exit 1
 
   # Force gcloud to use the preinstalled Python 3.14 environment
-  # which already has grpcio installed, preventing version mismatch conflicts
-  # with the system Python 3.12 dynamically pulled in by apk for py3-pip.
+  # which already has grpcio prepackaged, ensuring robust execution.
   export CLOUDSDK_PYTHON=python3
   export CLOUDSDK_PYTHON_SITEPACKAGES=1
 
@@ -126,7 +125,6 @@ EOF
   # https://cloud.google.com/logging/docs/reference/tools/gcloud-logging#install_live_tailing
   echo "Installing required gcloud alpha components..."
   gcloud --quiet components install alpha || exit 1
-  pip3 install grpcio --break-system-packages || exit 1
   echo "Streaming logs from the control node's startup script execution..."
   echo
 

--- a/presubmit_tests/infra-manager-lib.sh
+++ b/presubmit_tests/infra-manager-lib.sh
@@ -26,6 +26,13 @@ setup_vars() {
     exit 1
   fi
   apk add --no-cache zip curl py3-pip expect || exit 1
+
+  # Force gcloud to use the preinstalled Python 3.14 environment
+  # which already has grpcio installed, preventing version mismatch conflicts
+  # with the system Python 3.12 dynamically pulled in by apk for py3-pip.
+  export CLOUDSDK_PYTHON=python3
+  export CLOUDSDK_PYTHON_SITEPACKAGES=1
+
   gcs_bucket="gs://oracle-toolkit-presubmit-artifacts"
   # Append BUILD_ID to the file name to ensure each zip file gets a unique name.
   # This prevents one test from deleting the file while it's still in use by another concurrently running test.
@@ -128,15 +135,14 @@ EOF
   # 'unbuffer' is used here to avoid delayed and missing logs caused by output buffering in non-interactive session"
   # gcloud logging tail has a 1-hour session limit. We run it in a loop to maintain continuous log streaming beyond that limit.
   setsid bash <<EOF &
-    export CLOUDSDK_PYTHON_SITEPACKAGES=1
     while true; do
-      echo "$(date '+%Y-%m-%d %H:%M:%S')    Starting gcloud logging tail session..."
+      echo "\$(date '+%Y-%m-%d %H:%M:%S')    Starting gcloud logging tail session..."
       PYTHONWARNINGS="ignore" unbuffer gcloud alpha logging tail \
       "resource.type=gce_instance AND \
       resource.labels.instance_id=${control_node_instance_id} \
       AND log_name=projects/${project_id}/logs/google_metadata_script_runner" \
       --format='value(timestamp.date(format="%Y-%m-%d %H:%M:%S"), json_payload.message.sub("^startup-script: ", ""))'
-      echo "$(date '+%Y-%m-%d %H:%M:%S')     Tail session ended. Restarting..."
+      echo "\$(date '+%Y-%m-%d %H:%M:%S')     Tail session ended. Restarting..."
     done
 EOF
 

--- a/presubmit_tests/infra-manager-lib.sh
+++ b/presubmit_tests/infra-manager-lib.sh
@@ -26,12 +26,6 @@ setup_vars() {
     exit 1
   fi
   apk add --no-cache zip curl expect || exit 1
-
-  # Force gcloud to use the preinstalled Python 3.14 environment
-  # which already has grpcio prepackaged, ensuring robust execution.
-  export CLOUDSDK_PYTHON=python3
-  export CLOUDSDK_PYTHON_SITEPACKAGES=1
-
   gcs_bucket="gs://oracle-toolkit-presubmit-artifacts"
   # Append BUILD_ID to the file name to ensure each zip file gets a unique name.
   # This prevents one test from deleting the file while it's still in use by another concurrently running test.


### PR DESCRIPTION
Forces the Google Cloud CLI launcher to run on the prepackaged Python 3.14 environment (where grpcio is preinstalled) rather than defaulting to the system Python 3.12 environment (which is pulled in dynamically on Alpine by apk py3-pip package, but lacks grpcio).

This should fix loops like https://oss.gprow.dev/view/gs/gcp-oracle-prow-bucket/pr-logs/pull/google_oracle-toolkit/431/oracle-toolkit-install-26ai-data-guard-on-gcp/2059295359544332288

```
2026-05-26 15:29:55    Starting gcloud logging tail session...
ERROR: (gcloud.alpha.logging.tail) Please ensure that the gRPC module is installed and the environment is correctly configured. Run:
  sudo pip3 install grpcio
and set:
  export CLOUDSDK_PYTHON_SITEPACKAGES=1
For more information, see https://cloud.google.com/logging/docs/reference/tools/gcloud-logging#install_live_tailing
```

Also escapes dynamic date evaluations inside the Prow logging heredoc process group, ensuring live logs stream correctly in real-time.