### PR TITLE
Refactor ASM udev rules generation to overwrite file

### DIFF
--- a/roles/ora-host/tasks/main.yml
+++ b/roles/ora-host/tasks/main.yml
@@ -352,20 +352,6 @@
   with_items: "{{ udevadm_result_nonmultipath.results }}"
   tags: udev-mpath
 
-- name: (udev) Add ASM non-multipath disk rules (udev rules file)
-  become: true
-  become_user: root
-  blockinfile:
-    block: "SUBSYSTEM==\"block\" ACTION==\"add|change\", ENV{ID_SERIAL_SHORT}==\"{{ item.key }}\", SYMLINK+=\"{{ path_udev }}/{{ uuid_result_nonmultipath[item.key] | json_query('[*].name') | list | join(', ') }}\", GROUP=\"{{ grid_group }}\", OWNER=\"{{ grid_user }}\", MODE=\"0660\""
-    path: "/etc/udev/rules.d/99-oracle-asmdevices.rules"
-    marker: "# {mark} ASM disk udev rules for {{ uuid_result_nonmultipath[item.key] | json_query('[*].blk_device') | list | join(', ') }}"
-    create: true
-  register: udevRules_nonmultipath
-  when: uuid_result_nonmultipath is defined
-  with_dict:
-    - "{{ uuid_result_nonmultipath }}"
-  tags: udev-mpath
-
 ######## Udev rules for multipath disks ########
 
 - name: (udev) Add ASM mpath disk rules (udevadm info)
@@ -392,18 +378,16 @@
   with_items: "{{ udevadm_result.results }}"
   tags: udev-mpath
 
-- name: (udev) Add ASM mpath disk rules (udev rules file)
+- name: (udev) Generate ASM udev rules file
   become: true
   become_user: root
-  blockinfile:
-    block: "SUBSYSTEM==\"block\" ACTION==\"add|change\", ENV{DM_UUID}==\"{{ item.key }}\", SYMLINK+=\"{{ path_udev }}/{{ uuid_result[item.key] | json_query('[*].name') | list | join(', ') }}\", GROUP=\"{{ grid_group }}\", OWNER=\"{{ grid_user }}\", MODE=\"0660\""
-    path: "/etc/udev/rules.d/99-oracle-asmdevices.rules"
-    marker: "# {mark} ASM disk udev rules for {{ uuid_result[item.key] | json_query('[*].blk_device') | list | join(', ') }}"
-    create: true
-  register: udevRules
-  when: uuid_result is defined
-  with_dict:
-    - "{{ uuid_result }}"
+  template:
+    src: 99-oracle-asmdevices.rules.j2
+    dest: /etc/udev/rules.d/99-oracle-asmdevices.rules
+    owner: root
+    group: root
+    mode: '0644'
+  when: (uuid_result is defined and uuid_result) or (uuid_result_nonmultipath is defined and uuid_result_nonmultipath)
   tags: udev-mpath
 
 - name: (udev) reload rules

--- a/roles/ora-host/templates/99-oracle-asmdevices.rules.j2
+++ b/roles/ora-host/templates/99-oracle-asmdevices.rules.j2
@@ -1,0 +1,17 @@
+# ASM disk udev rules (Managed by https://github.com/google/oracle-toolkit)
+
+{% if uuid_result is defined and uuid_result %}
+# Multipath ASM disks
+{% for uuid, disk_list in uuid_result.items() %}
+# ASM disk udev rules for {{ disk_list | json_query('[*].blk_device') | list | join(', ') }}
+SUBSYSTEM=="block", ACTION=="add|change", ENV{DM_UUID}=="{{ uuid }}", SYMLINK+="{{ path_udev }}/{{ disk_list | json_query('[*].name') | list | join(', ') }}", GROUP="{{ grid_group }}", OWNER="{{ grid_user }}", MODE="0660"
+{% endfor %}
+{% endif %}
+
+{% if uuid_result_nonmultipath is defined and uuid_result_nonmultipath %}
+# Non-multipath ASM disks
+{% for serial, disk_list in uuid_result_nonmultipath.items() %}
+# ASM disk udev rules for {{ disk_list | json_query('[*].blk_device') | list | join(', ') }}
+SUBSYSTEM=="block", ACTION=="add|change", ENV{ID_SERIAL_SHORT}=="{{ serial }}", SYMLINK+="{{ path_udev }}/{{ disk_list | json_query('[*].name') | list | join(', ') }}", GROUP="{{ grid_group }}", OWNER="{{ grid_user }}", MODE="0660"
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
Previously, the toolkit used `blockinfile` to manage udev rules for ASM disks. While this works for initial deployments, it fails to clean up stale rules when storage is reconfigured (e.g. replacing smaller disks with larger ones) if the manual cleanup step (`cleanup.sh`) is bypassed. Stale rules mapped to the same symlink cause race conditions on boot.

Since a host only supports a single Grid Infrastructure / ASM installation, we can safely overwrite the entire `/etc/udev/rules.d/99-oracle-asmdevices.rules` file on every deployment.

This refactors the rules generation to use a Jinja2 template, replacing the `blockinfile` tasks. Stale rules are now automatically pruned when disks are removed from the configuration, improving toolkit resiliency.

Testing:
- Verified that rules are correctly generated and applied.
- Successfully deployed a test instance in the gcp-oracle-sandbox cloud environment using Infrastructure Manager and verified that ASM disk discovery and database installation completed without issues.