### PR TITLE
Fix control node resource ID retrieval in presubmit tests

### DIFF
--- a/presubmit_tests/infra-manager-lib.sh
+++ b/presubmit_tests/infra-manager-lib.sh
@@ -88,15 +88,22 @@ apply_deployment() {
 watch_logs() {
   # Extract the id of the control node resource
   # The format is: projects/<project>/zones/<zone>/instances/control-node-<random-suffix>
-  control_node_resource_id="$(gcloud infra-manager resources list \
-  --deployment="${deployment_name}" \
-  --location="${location}" \
-  --revision=r-0 \
-  --filter='terraformInfo.address=google_compute_instance.control_node' \
-  --format='value(terraformInfo.id)')" || {
+  local control_node_resource_id=""
+  while read -r address id; do
+    if [[ "${address}" == "google_compute_instance.control_node" ]]; then
+      control_node_resource_id="${id}"
+      break
+    fi
+  done < <(gcloud infra-manager resources list \
+    --deployment="${deployment_name}" \
+    --location="${location}" \
+    --revision=r-0 \
+    --format="value(terraformInfo.address,terraformInfo.id)")
+
+  if [[ -z "${control_node_resource_id}" ]]; then
     echo "Error: Failed to retrieve control node's resource ID." >&2
     exit 1
-  }
+  fi
 
   # Get the instance ID from the instance resource
   control_node_instance_id="$(gcloud compute instances describe "${control_node_resource_id}" --format="value(id)")" || {


### PR DESCRIPTION
# Troubleshooting Report: Oracle Toolkit Test Failure

We investigated the automated test failure in PR #439 (and #438).

## Issue Analysis

The test failed with the following error:
```
ERROR: (gcloud.compute.instances.describe) could not parse resource []
Error: Failed to get control node's instance ID.
```

This error occurred because the `CONTROL_NODE_RESOURCE_ID` variable was empty, which caused `gcloud compute instances describe` to fail when called with an empty argument.

The resource ID is retrieved using:
```bash
CONTROL_NODE_RESOURCE_ID="$(gcloud infra-manager resources list \
  --deployment="${deployment_name}" \
  --location="${location}" \
  --revision=r-0 \
  --filter='terraformInfo.address=google_compute_instance.control_node' \
  --format='value(terraformInfo.id)')"
```

A warning in the Prow logs pointed to the root cause:
```
WARNING: --filter : operator evaluation is changing for consistency across Google APIs.  terraformInfo.address=google_compute_instance.control_node currently does not match but will match in the near future.  Run `gcloud topic filters` for details.
```

The `gcloud` filter engine behavior is changing. Currently, the `=` operator on some APIs (including potentially Infra Manager in the version used by Prow) does not match the exact string due to deprecation of the older `:`-like behavior (word matching) for `=`.

## Solution

To make the resource retrieval robust against `gcloud` filter behavior changes, we modified the script to retrieve all resources with their addresses and IDs, and then perform the filtering in Bash.

This avoids relying on `gcloud`'s complex filter evaluation for nested fields.

We verified this fix against the active deployment `presubmit-dg-2071582511707721728` in the `gcp-oracle-benchmarks` project, and it successfully retrieved the resource and instance IDs.
