### PR TITLE
feat(tools): allow GIM update in-place and improve revision monitoring

### DIFF
--- a/tools/deploy-infra-manager.sh
+++ b/tools/deploy-infra-manager.sh
@@ -18,6 +18,9 @@
 
 set -e
 
+# Suppress gcloud progress indicators and spinners in logs
+export CLOUDSDK_CORE_INTERACTIVE_UX_STYLE=OFF
+
 # --- Path Calculations ---
 SCRIPT_PATH=$(readlink -f "$0")
 SCRIPT_DIR=$(dirname "$SCRIPT_PATH")
@@ -54,6 +57,7 @@ usage() {
   echo "  --force            Delete existing deployment before starting."
   echo "  --deployment-name  Deployment ID (default: oracle-deploy-$USER_CLEAN)"
   echo "  --project-id       GCP Project ID (defaults to active gcloud config)"
+  echo "  --provider-source  Terraform provider source (e.g. SERVICE_MAINTAINED)"
   exit 1
 }
 
@@ -62,6 +66,7 @@ DEPLOYMENT_NAME="oracle-deploy-${USER_CLEAN}"
 IM_LOCATION="us-central1"
 POLL_INTERVAL_SECONDS=5
 FORCE_DELETE=false
+PROVIDER_SOURCE=""
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -71,6 +76,7 @@ while [[ $# -gt 0 ]]; do
     --force) FORCE_DELETE=true; shift ;;
     --deployment-name) DEPLOYMENT_NAME="$2"; shift 2 ;;
     --project-id) PROJECT_ID="$2"; shift 2 ;;
+    --provider-source) PROVIDER_SOURCE="$2"; shift 2 ;;
     *) usage ;;
   esac
 done
@@ -83,13 +89,20 @@ PROJECT_ID=${PROJECT_ID:-$(gcloud config get-value project)}
 DEPLOYMENT_FULL_ID="projects/${PROJECT_ID}/locations/${IM_LOCATION}/deployments/${DEPLOYMENT_NAME}"
 
 # --- 1. Fresh Start Check ---
+PREV_REVISION_ID=""
 if gcloud infra-manager deployments describe "${DEPLOYMENT_FULL_ID}" --location="${IM_LOCATION}" >/dev/null 2>&1; then
+  PREV_REVISION_ID=$(gcloud infra-manager deployments describe "${DEPLOYMENT_FULL_ID}" \
+    --location="${IM_LOCATION}" --format="value(latestRevision)" 2>/dev/null || true)
+  if [[ "$PREV_REVISION_ID" == "null" || "$PREV_REVISION_ID" == "-" ]]; then
+    PREV_REVISION_ID=""
+  fi
+
   if [ "$FORCE_DELETE" = true ]; then
     echo "Existing deployment found. Deleting for fresh start..."
     gcloud infra-manager deployments delete "${DEPLOYMENT_FULL_ID}" --location="${IM_LOCATION}" --quiet
+    PREV_REVISION_ID=""
   else
-    echo "ERROR: Deployment '${DEPLOYMENT_NAME}' already exists. Use --force to recreate."
-    exit 1
+    echo "Existing deployment found. Updating in place..."
   fi
 fi
 
@@ -116,23 +129,86 @@ echo "Deployment Status Link: https://console.cloud.google.com/infra-manager/dep
 echo "---"
 
 echo "Submitting deployment via Infrastructure Manager..."
+set +e
 gcloud infra-manager deployments apply "${DEPLOYMENT_FULL_ID}" \
+  --async \
   --local-source="${PROJECT_ROOT}/terraform" \
   --inputs-file="${TEMPLATED_TFVARS}" \
   --location="${IM_LOCATION}" \
-  --service-account="projects/${PROJECT_ID}/serviceAccounts/${SERVICE_ACCOUNT}" || true
+  --service-account="projects/${PROJECT_ID}/serviceAccounts/${SERVICE_ACCOUNT}" \
+  ${PROVIDER_SOURCE:+--provider-source="${PROVIDER_SOURCE}"}
+APPLY_EXIT_CODE=$?
+set -e
 
 REVISION_ID=""
-while [[ -z "$REVISION_ID" ]]; do
-  REVISION_ID=$(gcloud infra-manager deployments describe "${DEPLOYMENT_FULL_ID}" \
-    --location="${IM_LOCATION}" --format="value(latestRevision)" 2>/dev/null || true)
-  [[ -n "$REVISION_ID" ]] && break
-  echo "Waiting for revision ID to be generated..."
-  sleep 2
+TIMEOUT_SECONDS=300
+ELAPSED_SECONDS=0
+while [[ -z "$REVISION_ID" || "$REVISION_ID" == "$PREV_REVISION_ID" ]]; do
+  # Fetch both state and latestRevision in one call
+  DEPLOY_INFO=$(gcloud infra-manager deployments describe "${DEPLOYMENT_FULL_ID}" \
+    --location="${IM_LOCATION}" --format="value(state,latestRevision)" 2>/dev/null || true)
+  
+  if [[ -n "$DEPLOY_INFO" ]]; then
+    read -r STATE REVISION_ID <<< "$DEPLOY_INFO"
+    # If latestRevision is not set, REVISION_ID might be empty or "null" depending on gcloud version
+    if [[ "$REVISION_ID" == "null" || "$REVISION_ID" == "-" ]]; then
+      REVISION_ID=""
+    fi
+    
+    if [[ "$STATE" == "FAILED" && ("$REVISION_ID" == "$PREV_REVISION_ID" || -z "$REVISION_ID") ]]; then
+      # Try one last time with list fallback before giving up
+      REVISION_SHORT_NAME=$(gcloud infra-manager revisions list \
+        --deployment="${DEPLOYMENT_NAME}" \
+        --location="${IM_LOCATION}" \
+        --format="value(name)" \
+        --sort-by="~createTime" \
+        --limit=1 2>/dev/null || true)
+      if [[ -n "$REVISION_SHORT_NAME" ]]; then
+        REVISION_ID="${DEPLOYMENT_FULL_ID}/revisions/${REVISION_SHORT_NAME}"
+      else
+        echo "ERROR: Deployment creation failed immediately without generating a revision."
+        exit 1
+      fi
+    fi
+  else
+    # Describe failed (e.g. deployment doesn't exist)
+    if [[ $APPLY_EXIT_CODE -ne 0 ]]; then
+      echo "ERROR: gcloud apply failed (exit code $APPLY_EXIT_CODE) and deployment was not created."
+      exit 1
+    fi
+  fi
+
+  # Fallback: if REVISION_ID is still empty or equal to previous, check revisions list
+  if [[ -z "$REVISION_ID" || "$REVISION_ID" == "$PREV_REVISION_ID" ]]; then
+    REVISION_SHORT_NAME=$(gcloud infra-manager revisions list \
+      --deployment="${DEPLOYMENT_NAME}" \
+      --location="${IM_LOCATION}" \
+      --format="value(name)" \
+      --sort-by="~createTime" \
+      --limit=1 2>/dev/null || true)
+    if [[ -n "$REVISION_SHORT_NAME" ]]; then
+      NEW_REVISION_ID="${DEPLOYMENT_FULL_ID}/revisions/${REVISION_SHORT_NAME}"
+      if [[ "$NEW_REVISION_ID" != "$PREV_REVISION_ID" ]]; then
+        REVISION_ID="${NEW_REVISION_ID}"
+        echo "Found new revision ${REVISION_SHORT_NAME} via list fallback."
+      fi
+    fi
+  fi
+
+  [[ -n "$REVISION_ID" && "$REVISION_ID" != "$PREV_REVISION_ID" ]] && break
+
+  if [[ $ELAPSED_SECONDS -ge $TIMEOUT_SECONDS ]]; then
+    echo "ERROR: Timeout waiting for new revision ID to be generated (5 minutes)."
+    exit 1
+  fi
+
+  echo "Waiting for new revision ID to be generated..."
+  sleep 5
+  ELAPSED_SECONDS=$((ELAPSED_SECONDS + 5))
 done
 
 # --- 5. Poll for Completion and Error Reporting ---
-echo "Monitoring Revision ${REVISION_ID##*}..."
+echo "Monitoring Revision ${REVISION_ID##*/}..."
 while true; do
   STATE=$(gcloud infra-manager revisions describe "${REVISION_ID}" --location="${IM_LOCATION}" --format="value(state)")
 


### PR DESCRIPTION
Based on testing for #439, this PR introduces improvements to the `deploy-infra-manager.sh` script to support iterative development:

1. **In-place Updates**: Allows updating an existing deployment in-place instead of failing immediately, enabling faster iteration.
2. **Silenced Progress**: Silences gcloud progress indicators in logs for cleaner output.
3. **Improved Revision Monitoring**: Robustly detects and monitors new revisions (recovering from failures and using fallback listing if needed).
4. **Provider Source**: Adds support for specifying a custom `--provider-source`.