### PR TITLE
Adding support for hyperdisk-extreme in Terraform

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -199,6 +199,38 @@ locals {
       ]
     ]) : entry.key => entry
   } : {}
+
+  # Every Hyperdisk this module creates: the boot disk plus additional_disks. Both
+  # creation paths (the inline instance-template disks and the standalone
+  # google_compute_disk.pool_disks) are built from this list.
+  managed_disk_devices = concat(
+    [{ device_name = "boot", disk_type = var.boot_disk_type, disk_size_gb = var.boot_disk_size_gb }],
+    [for d in local.additional_disks : { device_name = d.device_name, disk_type = d.disk_type, disk_size_gb = d.disk_size_gb }]
+  )
+
+  # hyperdisk-extreme constraints, enforced by the control_node preconditions below.
+  # Requires an M4N series machine type and a minimum of 200 GB per disk. It cannot
+  # back the boot disk or live in a Hyperdisk Storage Pool.
+  hyperdisk_extreme_type          = "hyperdisk-extreme"
+  hyperdisk_extreme_machine_regex = "^m4n-"
+  hyperdisk_extreme_min_size_gb   = 200
+
+  hyperdisk_extreme_devices = [
+    for d in local.managed_disk_devices : d.device_name
+    if lower(d.disk_type) == local.hyperdisk_extreme_type
+  ]
+
+  hyperdisk_extreme_undersized_devices = [
+    for d in local.managed_disk_devices : "${d.device_name} (${d.disk_size_gb} GB)"
+    if lower(d.disk_type) == local.hyperdisk_extreme_type && d.disk_size_gb < local.hyperdisk_extreme_min_size_gb
+  ]
+
+  # Storage Pools exist only for hyperdisk-balanced and hyperdisk-throughput. The
+  # boot disk is never pooled, so only additional_disks are checked here.
+  hyperdisk_extreme_pooled_devices = local.storage_pool_enabled ? [
+    for d in local.additional_disks : d.device_name
+    if lower(d.disk_type) == local.hyperdisk_extreme_type
+  ] : []
 }
 
 # Resolves info for the primary subnetwork (explicit or default)
@@ -598,6 +630,29 @@ resource "google_compute_instance" "control_node" {
         var.swap_disk_type == var.create_storage_pool.storage_pool_type
       )
       error_message = "When storage_pool is enabled, oracle_home_disk.type, data_disk.type, reco_disk.type, and swap_disk_type must all match storage_pool.storage_pool_type."
+    }
+
+    precondition {
+      condition = (
+        length(local.hyperdisk_extreme_devices) == 0 ||
+        can(regex(local.hyperdisk_extreme_machine_regex, lower(var.machine_type)))
+      )
+      error_message = "hyperdisk-extreme is requested for disk(s) [${join(", ", local.hyperdisk_extreme_devices)}], which requires an M4N series machine_type (m4n-*). Got machine_type '${var.machine_type}'."
+    }
+
+    precondition {
+      condition     = length(local.hyperdisk_extreme_undersized_devices) == 0
+      error_message = "hyperdisk-extreme requires at least ${local.hyperdisk_extreme_min_size_gb} GB per disk device. Increase the size of: ${join(", ", local.hyperdisk_extreme_undersized_devices)}."
+    }
+
+    precondition {
+      condition     = lower(var.boot_disk_type) != local.hyperdisk_extreme_type
+      error_message = "boot_disk_type must not be 'hyperdisk-extreme': hyperdisk-extreme volumes cannot be used as boot disks. Use 'hyperdisk-balanced' for the boot disk."
+    }
+
+    precondition {
+      condition     = length(local.hyperdisk_extreme_pooled_devices) == 0
+      error_message = "Hyperdisk Storage Pools only support hyperdisk-balanced and hyperdisk-throughput disks, so hyperdisk-extreme disk(s) [${join(", ", local.hyperdisk_extreme_pooled_devices)}] cannot be created inside a pool. Either change their type, or remove create_storage_pool / existing_storage_pools."
     }
 
     precondition {

--- a/terraform/ora121-gcnv.template
+++ b/terraform/ora121-gcnv.template
@@ -56,6 +56,10 @@ storage_backend = "gcnv"
 # --- Disk Settings ---
 # All Terraform installs create these three mandatory disks formatted as XFS:
 # /u01 (Home), /u02 (Data), and /u03 (RECO). This cannot be modified.
+# Disk type options (boot and swap only in this mode; u01/DATA/RECO are GCNV iSCSI LUNs):
+# "hyperdisk-balanced" (default), "hyperdisk-extreme", "pd-balanced", "pd-ssd", "pd-standard".
+# "hyperdisk-extreme" needs an M4N series machine_type, min 200 GB per disk, and cannot
+# be a boot disk or live in a Storage Pool.
 boot_disk_type    = "hyperdisk-balanced"
 boot_disk_size_gb = 50
 

--- a/terraform/ora26-gcnv.template
+++ b/terraform/ora26-gcnv.template
@@ -56,6 +56,10 @@ storage_backend = "gcnv"
 # --- Disk Settings ---
 # All Terraform installs create these three mandatory disks formatted as XFS:
 # /u01 (Home), /u02 (Data), and /u03 (RECO). This cannot be modified.
+# Disk type options (boot and swap only in this mode; u01/DATA/RECO are GCNV iSCSI LUNs):
+# "hyperdisk-balanced" (default), "hyperdisk-extreme", "pd-balanced", "pd-ssd", "pd-standard".
+# "hyperdisk-extreme" needs an M4N series machine_type, min 200 GB per disk, and cannot
+# be a boot disk or live in a Storage Pool.
 boot_disk_type    = "hyperdisk-balanced"
 boot_disk_size_gb = 50
 

--- a/terraform/terraform.tfvars.asm.example
+++ b/terraform/terraform.tfvars.asm.example
@@ -39,7 +39,9 @@ machine_type         = "n4-standard-2"
 # Feel free to adjust the disk sizes and types to match your requirements.
 # You can add more disks to the list below to create additional disks for ASM or filesystem.
 # fs_disks will be mounted as /u01, /u02, /u03, etc and formatted as XFS
-# Disk type options "pd-balanced", "pd-ssd", "pd-standard", "hyperdisk-extreme"
+# Disk type options: "hyperdisk-balanced" (default), "hyperdisk-extreme", "pd-balanced", "pd-ssd", "pd-standard"
+# "hyperdisk-extreme" needs an M4N series machine_type, min 200 GB per disk, and cannot
+# be a boot disk or live in a Storage Pool.
 boot_disk_type    = "hyperdisk-balanced"
 boot_disk_size_gb    = 50
 

--- a/terraform/terraform.tfvars.free.example
+++ b/terraform/terraform.tfvars.free.example
@@ -39,7 +39,9 @@ machine_type         = "n4-standard-2"
 # Feel free to adjust the disk sizes and types to match your requirements.
 # You can add more disks to the list below to create additional disks for ASM or filesystem.
 # fs_disks will be mounted as /u01, /u02, /u03, etc and formatted as XFS
-# Disk type options "pd-balanced", "pd-ssd", "pd-standard", "hyperdisk-extreme"
+# Disk type options: "hyperdisk-balanced" (default), "hyperdisk-extreme", "pd-balanced", "pd-ssd", "pd-standard"
+# "hyperdisk-extreme" needs an M4N series machine_type, min 200 GB per disk, and cannot
+# be a boot disk or live in a Storage Pool.
 boot_disk_type    = "hyperdisk-balanced"
 boot_disk_size_gb    = 50
 

--- a/terraform/terraform.tfvars.im.template
+++ b/terraform/terraform.tfvars.im.template
@@ -53,6 +53,9 @@ machine_type         = "n4-standard-2"
 # --- Disk Settings ---
 # All Terraform installs create these three mandatory disks formatted as XFS:
 # /u01 (Home), /u02 (Data), and /u03 (RECO). This cannot be modified.
+# Disk type options: "hyperdisk-balanced" (default), "hyperdisk-extreme", "pd-balanced", "pd-ssd", "pd-standard"
+# "hyperdisk-extreme" needs an M4N series machine_type, min 200 GB per disk, and cannot
+# be a boot disk or live in a Storage Pool.
 boot_disk_type    = "hyperdisk-balanced"
 boot_disk_size_gb = 50
 

--- a/terraform/terraform.tfvars.xfs.example
+++ b/terraform/terraform.tfvars.xfs.example
@@ -39,7 +39,9 @@ machine_type         = "n4-standard-2"
 # Feel free to adjust the disk sizes and types to match your requirements.
 # You can add more disks to the list below to create additional disks for ASM or filesystem.
 # fs_disks will be mounted as /u01, /u02, /u03, etc and formatted as XFS
-# Disk type options "pd-balanced", "pd-ssd", "pd-standard", "hyperdisk-extreme"
+# Disk type options: "hyperdisk-balanced" (default), "hyperdisk-extreme", "pd-balanced", "pd-ssd", "pd-standard"
+# "hyperdisk-extreme" needs an M4N series machine_type, min 200 GB per disk, and cannot
+# be a boot disk or live in a Storage Pool.
 boot_disk_type    = "hyperdisk-balanced"
 boot_disk_size_gb    = 50
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -214,7 +214,7 @@ variable "boot_disk_size_gb" {
 }
 
 variable "boot_disk_type" {
-  description = "The type of the boot disk for the database VM."
+  description = "The type of the boot disk for the database VM. 'hyperdisk-extreme' is not supported for boot disks."
   type        = string
   default     = "hyperdisk-balanced"
 }
@@ -226,13 +226,13 @@ variable "swap_disk_size_gb" {
 }
 
 variable "swap_disk_type" {
-  description = "The type of the swap disk for the database VM."
+  description = "The type of the swap disk for the database VM. 'hyperdisk-extreme' requires an M4N series machine_type and at least 200 GB."
   type        = string
   default     = "hyperdisk-balanced"
 }
 
 variable "oracle_home_disk" {
-  description = "The Oracle binaries (/u01) disk."
+  description = "The Oracle binaries (/u01) disk. type = 'hyperdisk-extreme' requires an M4N series machine_type and size_gb of at least 200."
   type = object({
     size_gb = optional(number, 100)
     type    = optional(string, "hyperdisk-balanced")
@@ -244,7 +244,7 @@ variable "oracle_home_disk" {
 }
 
 variable "data_disk" {
-  description = "The Oracle data disk."
+  description = "The Oracle data disk. type = 'hyperdisk-extreme' requires an M4N series machine_type and size_gb of at least 200."
   type = object({
     size_gb = optional(number, 100)
     type    = optional(string, "hyperdisk-balanced")
@@ -256,7 +256,7 @@ variable "data_disk" {
 }
 
 variable "reco_disk" {
-  description = "The Oracle fast recovery area disk."
+  description = "The Oracle fast recovery area disk. type = 'hyperdisk-extreme' requires an M4N series machine_type and size_gb of at least 200."
   type = object({
     size_gb = optional(number, 100)
     type    = optional(string, "hyperdisk-balanced")
@@ -295,7 +295,7 @@ variable "create_storage_pool" {
       ["hyperdisk-balanced", "hyperdisk-throughput"],
       try(var.create_storage_pool.storage_pool_type, "hyperdisk-balanced")
     )
-    error_message = "storage_pool.storage_pool_type must be 'hyperdisk-balanced' or 'hyperdisk-throughput'."
+    error_message = "storage_pool.storage_pool_type must be 'hyperdisk-balanced' or 'hyperdisk-throughput'. Hyperdisk Storage Pools are not offered for other disk types; in particular 'hyperdisk-extreme' disks cannot be created in, or attached to, a storage pool."
   }
 
   validation {


### PR DESCRIPTION
### Change Description:
Add terraform support for provisioning `hyperdisk-extreme` disks.

`hyperdisk-extreme` is the highest-performance Hyperdisk tier and is a good fit for
Oracle DATA and RECO volumes on I/O-bound workloads. It carries platform constraints
that the terraform layer did not previously know about, so an invalid combination
only failed at apply time with a GCE API error.

### Solution Overview:
Any of the disk type variables (`boot_disk_type`, `swap_disk_type`,
`oracle_home_disk.type`, `data_disk.type`, `reco_disk.type`) now accept
`"hyperdisk-extreme"`, validated at plan time by preconditions on the control node:

- Requires an M4N series `machine_type` (`m4n-*`).
- Minimum 200 GB per disk device. Checked per device, and only for devices whose own
  type is `hyperdisk-extreme`, so mixed configurations (e.g. `hyperdisk-extreme` DATA
  alongside `hyperdisk-balanced` RECO) validate correctly.
- Cannot back the boot disk.
- Cannot be created in, or attached to, a Hyperdisk Storage Pool. Pools exist only for
  `hyperdisk-balanced` and `hyperdisk-throughput`.
- IOPS and throughput are never provisioned; the disks use the GCE defaults.

Validation is driven off `local.managed_disk_devices` (boot plus
`local.additional_disks`), which is the same list feeding both disk creation paths —
the inline `dynamic "disk"` blocks of the instance template and the standalone
`google_compute_disk.pool_disks` used when a storage pool is enabled — so both are
covered by one set of rules. GCNV mode is unaffected: `u01`/DATA/RECO are iSCSI LUNs
there and are already excluded from `local.additional_disks`.

The rules live in a single locals block (`hyperdisk_extreme_machine_regex`,
`hyperdisk_extreme_min_size_gb`) so they can be amended in one place.

Test Commands:
```
terraform init
terraform plan
```

Test Prep:
```
machine_type = "m4n-megamem-28"

data_disk = {
  size_gb = 300
  type    = "hyperdisk-extreme"
}
```
The `terraform.tfvars.*.example` files and the GCNV templates document the disk type
options and the `hyperdisk-extreme` constraints.

### Test 1: details:
A valid configuration (M4N machine type, `hyperdisk-extreme` disks at 200 GB or more,
no storage pool) plans and applies. Invalid combinations are rejected at plan time
rather than by the GCE API mid-apply.

The implementation should be transparent for other components of toolkit — the disk
type is never passed to `install-oracle.sh`, only the resulting `blk_device` paths and
`device_name`s, which are unchanged.

### Expected Results:
| Configuration | Result |
| --- | --- |
| `hyperdisk-extreme` DATA 300 GB on `m4n-megamem-28` | plan succeeds |
| `hyperdisk-extreme` on a non-M4N machine type | rejected: requires an M4N series machine_type |
| `hyperdisk-extreme` disk below 200 GB | rejected: names each undersized device and its size |
| `boot_disk_type = "hyperdisk-extreme"` | rejected: cannot be used as a boot disk |
| `hyperdisk-extreme` with a storage pool enabled | rejected: pools support balanced/throughput only |
| All disks `hyperdisk-balanced` (existing configs) | unchanged, no new failures |

### API verification results

The Cloud console does not currently offer `hyperdisk-extreme` when adding a disk to an
M4N VM, so support was confirmed directly against the API in `europe-west1-c`:

```
=== Test 1: create standalone 200GB hyperdisk-extreme ===
NAME                           ZONE            SIZE_GB  TYPE               STATUS
hxprobe-1785254188-standalone  europe-west1-c  200      hyperdisk-extreme  READY
>>> Test 1 PASS -- standalone hyperdisk-extreme disk created

=== Test 2: m4n-megamem-28 + inline hyperdisk-extreme ===
NAME                    ZONE            MACHINE_TYPE    STATUS
hxprobe-1785254188-m4n  europe-west1-c  m4n-megamem-28  RUNNING
>>> Test 2 PASS -- m4n-megamem-28 accepted an inline hyperdisk-extreme

=== Test 3: attach standalone hyperdisk-extreme to hxprobe-1785254188-m4n ===
>>> Test 3 PASS -- separately-created hyperdisk-extreme attached
```

`m4n-megamem-28` (28 vCPUs) accepts `hyperdisk-extreme` on both the inline
`--create-disk` path and the create-then-attach path, matching the two paths the
terraform module uses. `gcloud compute disk-types list` reports
`VALID_DISK_SIZES 64GB-65536GB` for the type; the 200 GB minimum enforced here is the
stricter figure required for this deployment.

`terraform validate` passes and `terraform fmt -check` is clean for `main.tf` and
`variables.tf`.

[oratk59-13 terraform test results](https://gist.github.com/GMafra/4b8ae23ceca9cf24ccc1a162b5905512)